### PR TITLE
feat(admin-reservation): 관리자 예약 관리 기능 구현

### DIFF
--- a/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
@@ -19,11 +19,26 @@ public class AdminReservationController {
 
     private final AdminReservationService adminReservationService;
 
+    /** 예약 목록 조회 매핑
+     *
+     * @param pageable
+     * @return 200 + 페이징 목록
+     */
     @GetMapping
     public ResponseEntity<Page<AdminReservationPageResponse>> getReservations(Pageable pageable) {
         return ResponseEntity.ok(adminReservationService.getReservationList(pageable));
     }
 
+    /** 예약 검색 목록 매핑
+     *
+     * @param pageable 페이징
+     * @param userName 검색할 회원 이름
+     * @param performanceTitle 검색할 공연 제목
+     * @param reservationStatus 검색할 예약 상태
+     * @param startDate 검색 필터링에 사용할 시작 날짜
+     * @param endDate 검색 필터링에 사용할 종료 날짜
+     * @return 200 + 검색 페이징 목록
+     */
     @GetMapping("/search")
     public ResponseEntity<Page<AdminReservationPageResponse>> searchReservations(Pageable pageable,
                                                                                  @RequestParam(required = false) String userName,
@@ -41,6 +56,11 @@ public class AdminReservationController {
         ));
     }
 
+    /** 예약 상태 변경
+     * 예약 대기 상태라면 확정으로
+     *
+     * @param reservationId
+     */
     @PatchMapping("/{reservationId}")
     public ResponseEntity<Void> confirmReservation(@PathVariable Long reservationId) {
         adminReservationService.confirmReservation(reservationId);

--- a/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 
 @RestController
-@RequestMapping("/admin/reservations")
+@RequestMapping("/api/v1/admin/reservations")
 @RequiredArgsConstructor
 public class AdminReservationController {
 

--- a/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
@@ -1,0 +1,50 @@
+package me.performancereservation.api;
+
+import lombok.RequiredArgsConstructor;
+import me.performancereservation.domain.admin.dto.AdminReservationPageResponse;
+import me.performancereservation.domain.admin.service.AdminReservationService;
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/admin/reservations")
+@RequiredArgsConstructor
+public class AdminReservationController {
+
+    private final AdminReservationService adminReservationService;
+
+    @GetMapping
+    public ResponseEntity<Page<AdminReservationPageResponse>> getReservations(Pageable pageable) {
+        return ResponseEntity.ok(adminReservationService.getReservationList(pageable));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<AdminReservationPageResponse>> searchReservations(Pageable pageable,
+                                                                                 @RequestParam(required = false) String userName,
+                                                                                 @RequestParam(required = false) String performanceTitle,
+                                                                                 @RequestParam(required = false)ReservationStatus reservationStatus,
+                                                                                 @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+                                                                                 @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+        return ResponseEntity.ok(adminReservationService.searchReservationList(
+                pageable,
+                userName,
+                performanceTitle,
+                reservationStatus,
+                startDate,
+                endDate
+        ));
+    }
+
+    @PatchMapping("/{reservationId}")
+    public ResponseEntity<Void> confirmReservation(@PathVariable Long reservationId) {
+        adminReservationService.confirmReservation(reservationId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/backend/src/main/java/me/performancereservation/api/ManagerPerformanceController.java
+++ b/backend/src/main/java/me/performancereservation/api/ManagerPerformanceController.java
@@ -3,11 +3,10 @@ package me.performancereservation.api;
 
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.file.FileService;
-import me.performancereservation.domain.file.dto.UploadFileResponse;
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceCreateRequest;
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceUpdateRequest;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerDetailResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerListResponse;
+import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerPageResponse;
 import me.performancereservation.domain.performance.service.PerformanceScheduleService;
 import me.performancereservation.domain.performance.service.PerformanceService;
 import org.springframework.data.domain.Page;
@@ -17,7 +16,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/managers")
@@ -35,13 +33,13 @@ public class ManagerPerformanceController {
      * @return 200 + Page<PerformanceManagerListResponse>
      */
     @GetMapping("/performances")
-    public ResponseEntity<Page<PerformanceManagerListResponse>> getPerformances(
+    public ResponseEntity<Page<PerformanceManagerPageResponse>> getPerformances(
             @PageableDefault(
                     size=10,
                     sort = "performanceDate",
                     direction = Sort.Direction.DESC) Pageable pageable,
             Long managerId) {
-        Page<PerformanceManagerListResponse> PerformanceManagerPageResponse = performanceService.getPerformanceManagerList(pageable, managerId);
+        Page<PerformanceManagerPageResponse> PerformanceManagerPageResponse = performanceService.getPerformanceManagerList(pageable, managerId);
         return ResponseEntity.ok(PerformanceManagerPageResponse);
     }
 

--- a/backend/src/main/java/me/performancereservation/api/UserPerformanceController.java
+++ b/backend/src/main/java/me/performancereservation/api/UserPerformanceController.java
@@ -2,8 +2,7 @@ package me.performancereservation.api;
 
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceDetailResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceListResponse;
-import me.performancereservation.domain.performance.repository.PerformanceRepository;
+import me.performancereservation.domain.performance.dto.performance.response.PerformancePageResponse;
 import me.performancereservation.domain.performance.service.PerformanceScheduleService;
 import me.performancereservation.domain.performance.service.PerformanceService;
 import org.springframework.data.domain.Page;
@@ -31,9 +30,9 @@ public class UserPerformanceController {
      * @return 200 + performanceResponses
      */
     @GetMapping
-    public ResponseEntity<Page<PerformanceListResponse>> getPerformanceList(
+    public ResponseEntity<Page<PerformancePageResponse>> getPerformanceList(
             @PageableDefault(size=10, sort = "performanceDate", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<PerformanceListResponse> performancePageResponse = performanceService.getPerformanceList(pageable);
+        Page<PerformancePageResponse> performancePageResponse = performanceService.getPerformanceList(pageable);
         return ResponseEntity.ok(performancePageResponse);
     }
 

--- a/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
@@ -1,0 +1,18 @@
+package me.performancereservation.domain.admin.dto;
+
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+
+import java.time.LocalDateTime;
+
+public record AdminReservationPageResponse(
+        Long reservationId,
+        Long performanceId,
+        Long performanceScheduleId,
+        String name,
+        String title,
+        int price,
+        int quantity,
+        ReservationStatus status,
+        LocalDateTime createdAt
+) {
+}

--- a/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
@@ -4,6 +4,18 @@ import me.performancereservation.domain.reservation.enums.ReservationStatus;
 
 import java.time.LocalDateTime;
 
+/** 관리자 예약 목록 응답용
+ *
+ * @param reservationId 예약 id
+ * @param performanceId 공연 id
+ * @param performanceScheduleId 회차 id
+ * @param name 고객 이름
+ * @param title 공연 제목
+ * @param price 가격
+ * @param quantity 수량
+ * @param status 예약 상태
+ * @param createdAt 예약 생성 일시
+ */
 public record AdminReservationPageResponse(
         Long reservationId,
         Long performanceId,

--- a/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
@@ -24,6 +24,7 @@ public record AdminReservationPageResponse(
         String title,
         int price,
         int quantity,
+        int totalPrice,
         ReservationStatus status,
         LocalDateTime createdAt
 ) {

--- a/backend/src/main/java/me/performancereservation/domain/admin/repository/AdminReservationRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/repository/AdminReservationRepository.java
@@ -1,0 +1,88 @@
+package me.performancereservation.domain.admin.repository;
+
+import me.performancereservation.domain.admin.dto.AdminReservationPageResponse;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface AdminReservationRepository extends JpaRepository<Reservation, Long> {
+
+    /** 관리자가 예약 목록 조회를 위한 조회 쿼리
+     *
+     * 4 개의 테이블을 조인해 필요한 필드를 dto 로 반환
+     * 최신순 출력을 위해 생성 시간 내림차순 정렬
+     * @param pageable
+     * @return AdminReservationPageResponse
+     */
+    @Query("""
+    SELECT new me.performancereservation.domain.admin.dto.AdminReservationPageResponse(
+        r.id,
+        p.id,
+        s.id,
+        u.name,
+        p.title,
+        p.price,
+        r.quantity,
+        r.status,
+        r.createdAt
+    )
+    FROM Reservation r
+    JOIN User u ON r.userId = u.id
+    JOIN PerformanceSchedule s ON r.scheduleId = s.id
+    JOIN Performance p ON s.performanceId = p.id
+    ORDER BY r.createdAt DESC
+""")
+    Page<AdminReservationPageResponse> findAdminReservations(Pageable pageable);
+
+
+    /** 예약 목록 검색 쿼리
+     *
+     * 검색 조건 (고객 이름, 공연 제목, 예약 상태, 날짜)
+     * 이름 + 예약 상태(전체, 대기, 확정 등) + 날짜(구간 필터링, 선택 안하는 경우 전체 검색)
+     * 공연 + 예약 상태(전체, 대기, 확정 등) + 날짜(구간 필터링, 선택 안하는 경우 전체 검색)
+     * @param userName
+     * @param performanceTitle
+     * @param reservationStatus
+     * @param pageable
+     * @return AdminReservationPageResponse
+     */
+    @Query("""
+    SELECT new me.performancereservation.domain.admin.dto.AdminReservationPageResponse(
+        r.id,
+        p.id,
+        s.id,
+        u.name,
+        p.title,
+        p.price,
+        r.quantity,
+        r.status,
+        r.createdAt
+    )
+    FROM Reservation r
+    JOIN User u ON r.userId = u.id
+    JOIN PerformanceSchedule s ON r.scheduleId = s.id
+    JOIN Performance p ON s.performanceId = p.id
+    WHERE 
+        (:userName IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :userName, '%'))) 
+        AND (:performanceTitle IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :performanceTitle, '%'))) 
+        AND (:reservationStatus IS NULL OR r.status = :reservationStatus)
+        AND (:startDate IS NULL OR r.createdAt >= :startDate)
+        AND (:endDate IS NULL OR r.createdAt <= :endDate)
+    ORDER BY r.createdAt DESC
+""")
+    Page<AdminReservationPageResponse> searchAdminReservations(
+            @Param("userName") String userName,
+            @Param("performanceTitle") String performanceTitle,
+            @Param("reservationStatus") ReservationStatus reservationStatus,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable
+    );
+
+}

--- a/backend/src/main/java/me/performancereservation/domain/admin/repository/AdminReservationRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/repository/AdminReservationRepository.java
@@ -29,6 +29,7 @@ public interface AdminReservationRepository extends JpaRepository<Reservation, L
         p.title,
         p.price,
         r.quantity,
+        (p.price * r.quantity),
         r.status,
         r.createdAt
     )
@@ -61,6 +62,7 @@ public interface AdminReservationRepository extends JpaRepository<Reservation, L
         p.title,
         p.price,
         r.quantity,
+        (p.price * r.quantity),
         r.status,
         r.createdAt
     )

--- a/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
@@ -20,11 +20,26 @@ public class AdminReservationService {
     private final ReservationRepository reservationRepository;
     private final AdminReservationRepository adminReservationRepository;
 
+    /** 관리자 예약 목록 조회
+     *
+     * @param pageable
+     * @return AdminReservationPageResponse
+     */
     @Transactional(readOnly = true)
     public Page<AdminReservationPageResponse> getReservationList(Pageable pageable) {
         return adminReservationRepository.findAdminReservations(pageable);
     }
 
+    /** 관리자 예약 목록 검색
+     *
+     * @param pageable 페이징
+     * @param userName 회원 이름(검색 키)
+     * @param performanceTitle 공연 제목(검색 키)
+     * @param reservationStatus 예약 상태(검색 키)
+     * @param startDate 시작 날짜(검색 키)
+     * @param endDate 종료 날짜(검색 키)
+     * @return AdminReservationPageResponse
+     */
     @Transactional(readOnly = true)
     public Page<AdminReservationPageResponse> searchReservationList(Pageable pageable,
                                                                     String userName,
@@ -35,6 +50,11 @@ public class AdminReservationService {
         return adminReservationRepository.searchAdminReservations(userName, performanceTitle, reservationStatus, startDate, endDate, pageable);
     }
 
+    /** 관리자 예약 확정 상태 변경
+     *
+     * 예약을 확정 상태로 변경
+     * @param reservationId 예약 id
+     */
     @Transactional
     public void confirmReservation(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)

--- a/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
@@ -1,0 +1,46 @@
+package me.performancereservation.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import me.performancereservation.domain.admin.dto.AdminReservationPageResponse;
+import me.performancereservation.domain.admin.repository.AdminReservationRepository;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.ReservationRepository;
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import me.performancereservation.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AdminReservationService {
+    private final ReservationRepository reservationRepository;
+    private final AdminReservationRepository adminReservationRepository;
+
+    @Transactional(readOnly = true)
+    public Page<AdminReservationPageResponse> getReservationList(Pageable pageable) {
+        return adminReservationRepository.findAdminReservations(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AdminReservationPageResponse> searchReservationList(Pageable pageable,
+                                                                    String userName,
+                                                                    String performanceTitle,
+                                                                    ReservationStatus reservationStatus,
+                                                                    LocalDateTime startDate,
+                                                                    LocalDateTime endDate) {
+        return adminReservationRepository.searchAdminReservations(userName, performanceTitle, reservationStatus, startDate, endDate, pageable);
+    }
+
+    @Transactional
+    public void confirmReservation(Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> ErrorCode.RESERVATION_NOT_FOUND.domainException("예약이 존재하지 않습니다."));
+
+        reservation.confirm();
+    }
+
+}

--- a/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
@@ -67,8 +67,8 @@ public class AdminReservationService {
         PerformanceSchedule schedule = performanceScheduleRepository.findById(reservation.getScheduleId())
                 .orElseThrow(() -> ErrorCode.PERFORMANCE_SCHEDULE_NOT_FOUND.domainException("회차가 존재하지 않습니다."));
 
-        schedule.decreaseRemainingSeats(reservation.getQuantity());
         reservation.confirm();
+        schedule.decreaseRemainingSeats(reservation.getQuantity());
     }
 
 }

--- a/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/service/AdminReservationService.java
@@ -3,6 +3,8 @@ package me.performancereservation.domain.admin.service;
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.admin.dto.AdminReservationPageResponse;
 import me.performancereservation.domain.admin.repository.AdminReservationRepository;
+import me.performancereservation.domain.performance.entities.PerformanceSchedule;
+import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
 import me.performancereservation.domain.reservation.Reservation;
 import me.performancereservation.domain.reservation.ReservationRepository;
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
@@ -19,6 +21,7 @@ import java.time.LocalDateTime;
 public class AdminReservationService {
     private final ReservationRepository reservationRepository;
     private final AdminReservationRepository adminReservationRepository;
+    private final PerformanceScheduleRepository performanceScheduleRepository;
 
     /** 관리자 예약 목록 조회
      *
@@ -60,6 +63,11 @@ public class AdminReservationService {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> ErrorCode.RESERVATION_NOT_FOUND.domainException("예약이 존재하지 않습니다."));
 
+
+        PerformanceSchedule schedule = performanceScheduleRepository.findById(reservation.getScheduleId())
+                .orElseThrow(() -> ErrorCode.PERFORMANCE_SCHEDULE_NOT_FOUND.domainException("회차가 존재하지 않습니다."));
+
+        schedule.decreaseRemainingSeats(reservation.getQuantity());
         reservation.confirm();
     }
 

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerPageResponse.java
@@ -2,21 +2,21 @@ package me.performancereservation.domain.performance.dto.performance.response;
 
 import java.time.LocalDateTime;
 
-/** 고객 공연 목록 페이지 응답용
+/** 공연 관리자 공연 목록 페이지 응답용
  *
  * @param id
- * @param fileUrl   // 썸네일 파일 주소
+ * @param fileUrl
  * @param title
- * @param price
  * @param performanceDate
  * @param venue
+ * @param status    // 공연 등록 여부 (PENDING, CONFIRM 등)
  */
-public record PerformanceListResponse(
+public record PerformanceManagerPageResponse(
         Long id,
         String fileUrl,
         String title,
-        int price,
         LocalDateTime performanceDate,
-        String venue
+        String venue,
+        String status
 ) {
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformancePageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformancePageResponse.java
@@ -2,21 +2,21 @@ package me.performancereservation.domain.performance.dto.performance.response;
 
 import java.time.LocalDateTime;
 
-/** 공연 관리자 공연 목록 페이지 응답용
+/** 고객 공연 목록 페이지 응답용
  *
  * @param id
- * @param fileUrl
+ * @param fileUrl   // 썸네일 파일 주소
  * @param title
+ * @param price
  * @param performanceDate
  * @param venue
- * @param status    // 공연 등록 여부 (PENDING, CONFIRM 등)
  */
-public record PerformanceManagerListResponse(
+public record PerformancePageResponse(
         Long id,
         String fileUrl,
         String title,
+        int price,
         LocalDateTime performanceDate,
-        String venue,
-        String status
+        String venue
 ) {
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/entities/PerformanceSchedule.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/entities/PerformanceSchedule.java
@@ -45,6 +45,13 @@ public class PerformanceSchedule extends BaseEntity {
         this.canceled = true;
     }
 
+    public void decreaseRemainingSeats(int quantity) {
+        if(this.remainingSeats < quantity) {
+            throw ErrorCode.NO_REMAINING_SEATS.domainException("잔여 좌석이 부족합니다. remainingSeats = " + this.remainingSeats);
+        }
+        this.remainingSeats -= quantity;
+    }
+
     public boolean hasPermission(Long performanceId) {
         return performanceId != null && performanceId.equals(this.performanceId);
     }

--- a/backend/src/main/java/me/performancereservation/domain/performance/mapper/PerformanceMapper.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/mapper/PerformanceMapper.java
@@ -2,9 +2,9 @@ package me.performancereservation.domain.performance.mapper;
 
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceCreateRequest;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceDetailResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceListResponse;
+import me.performancereservation.domain.performance.dto.performance.response.PerformancePageResponse;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerDetailResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerListResponse;
+import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerPageResponse;
 import me.performancereservation.domain.performance.dto.performanceschedule.PerformanceScheduleResponse;
 import me.performancereservation.domain.performance.entities.Performance;
 import me.performancereservation.domain.performance.entities.PerformanceSchedule;
@@ -63,8 +63,8 @@ public class PerformanceMapper {
      * @param fileUrl
      * @return PerformanceListResponse
      */
-    public static PerformanceListResponse toListResponse(Performance performance, String fileUrl) {
-        return new PerformanceListResponse(
+    public static PerformancePageResponse toListResponse(Performance performance, String fileUrl) {
+        return new PerformancePageResponse(
                 performance.getId(),
                 fileUrl,
                 performance.getTitle(),
@@ -80,8 +80,8 @@ public class PerformanceMapper {
      * @param fileUrl
      * @return PerformanceManagerListResponse
      */
-    public static PerformanceManagerListResponse toManagerListResponse(Performance performance, String fileUrl) {
-        return new PerformanceManagerListResponse(
+    public static PerformanceManagerPageResponse toManagerListResponse(Performance performance, String fileUrl) {
+        return new PerformanceManagerPageResponse(
                 performance.getId(),
                 fileUrl,
                 performance.getTitle(),

--- a/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
@@ -7,9 +7,9 @@ import me.performancereservation.domain.file.FileRepository;
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceCreateRequest;
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceUpdateRequest;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceDetailResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceListResponse;
+import me.performancereservation.domain.performance.dto.performance.response.PerformancePageResponse;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerDetailResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerListResponse;
+import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerPageResponse;
 import me.performancereservation.domain.performance.dto.performanceschedule.PerformanceScheduleResponse;
 import me.performancereservation.domain.performance.entities.Performance;
 import me.performancereservation.domain.performance.entities.PerformanceSchedule;
@@ -20,8 +20,6 @@ import me.performancereservation.domain.performance.repository.PerformanceSchedu
 import me.performancereservation.global.exception.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -106,7 +104,7 @@ public class PerformanceService {
      * @return Page<PerformanceListResponse>
      */
     @Transactional(readOnly = true)
-    public Page<PerformanceListResponse> getPerformanceList(Pageable pageable) {
+    public Page<PerformancePageResponse> getPerformanceList(Pageable pageable) {
         // 페이징된 공연 조회
         Page<Performance> performances = performanceRepository.findAvailablePerformances(pageable);
 
@@ -160,7 +158,7 @@ public class PerformanceService {
      * @return Page<PerformanceManagerListResponse>
      */
     @Transactional(readOnly = true)
-    public Page<PerformanceManagerListResponse> getPerformanceManagerList(Pageable pageable, Long managerId) {
+    public Page<PerformanceManagerPageResponse> getPerformanceManagerList(Pageable pageable, Long managerId) {
         // 공연자의 모든 공연을 페이징 하여 가져옴
         Page<Performance> performances = performanceRepository.findByManagerId(managerId, pageable);
 

--- a/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import me.performancereservation.domain.common.BaseEntity;
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import me.performancereservation.global.exception.ErrorCode;
 
 @Entity
 @Getter
@@ -30,5 +31,12 @@ public class Reservation extends BaseEntity {
         this.scheduleId = scheduleId;
         this.quantity = quantity;
         this.status = status;
+    }
+
+    public void confirm() {
+        if(this.status == ReservationStatus.PAYMENTS_CONFIRMED) {
+            throw ErrorCode.RESERVATION_ALREADY_CONFIRMED.domainException("이미 확정된 예약입니다.");
+        }
+        this.status = ReservationStatus.PAYMENTS_CONFIRMED;
     }
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
@@ -81,9 +81,13 @@ public class Reservation extends BaseEntity {
         return this.quantity * ticketPrice;
     }
 
+    // 예약 확정
     public void confirm() {
         if(this.status == ReservationStatus.PAYMENTS_CONFIRMED) {
             throw ErrorCode.RESERVATION_ALREADY_CONFIRMED.domainException("이미 확정된 예약입니다.");
+        }
+        if(this.status == ReservationStatus.CANCEL_PENDING || this.status == ReservationStatus.CANCEL_CONFIRMED) {
+            throw ErrorCode.INVALID_RESERVATION_STATUS.domainException("유효하지 않은 예약 상태입니다.");
         }
         this.status = ReservationStatus.PAYMENTS_CONFIRMED;
     }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
@@ -86,7 +86,7 @@ public class Reservation extends BaseEntity {
         if(this.status == ReservationStatus.PAYMENTS_CONFIRMED) {
             throw ErrorCode.RESERVATION_ALREADY_CONFIRMED.domainException("이미 확정된 예약입니다.");
         }
-        if(this.status == ReservationStatus.CANCEL_PENDING || this.status == ReservationStatus.CANCEL_CONFIRMED) {
+        if(isAlreadyCanceled()) {
             throw ErrorCode.INVALID_RESERVATION_STATUS.domainException("유효하지 않은 예약 상태입니다.");
         }
         this.status = ReservationStatus.PAYMENTS_CONFIRMED;

--- a/backend/src/main/java/me/performancereservation/global/exception/ErrorCode.java
+++ b/backend/src/main/java/me/performancereservation/global/exception/ErrorCode.java
@@ -27,8 +27,10 @@ public enum ErrorCode {
     PERFORMANCE_PENDING_APPROVAL(HttpStatus.BAD_REQUEST, "공연이 승인 대기 중입니다. 승인 후 회차 등록이 가능합니다."),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지를 찾을 수 없습니다."),
     PERFORMANCE_ALREADY_CANCELED(HttpStatus.CONFLICT, "이미 취소된 공연입니다."),
-    SCHEDULE_ALREADY_CANCELED(HttpStatus.CONFLICT, "이미 취소된 회차입니다.");
+    SCHEDULE_ALREADY_CANCELED(HttpStatus.CONFLICT, "이미 취소된 회차입니다."),
     // 예약 관련
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND,  "해당하는 예약이 없습니다."),
+    RESERVATION_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 확정된 예약입니다.");
 
     // 환불 관련
 

--- a/backend/src/main/java/me/performancereservation/global/exception/ErrorCode.java
+++ b/backend/src/main/java/me/performancereservation/global/exception/ErrorCode.java
@@ -34,12 +34,12 @@ public enum ErrorCode {
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND,  "해당하는 예약이 없습니다."),
     ALREADY_CANCELED_RESERVATION(HttpStatus.BAD_REQUEST, "이미 취소된 예약입니다."),
     INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 예약 상태입니다."),
+    RESERVATION_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 확정된 예약입니다."),
 
-    // 좌석 재고 관련
+    // 좌석 재고 관련,
     NO_REMAINING_SEATS(HttpStatus.BAD_REQUEST, "남은 좌석이 없습니다."),
     SEAT_STOCK_DECREMENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "좌석 차감에 실패했습니다."),
     SEAT_STOCK_INCREMENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "좌석 복원에 실패했습니다."),
-    RESERVATION_ALREADY_CONFIRMED(HttpStatus.CONFLICT, "이미 확정된 예약입니다."),
 
     // 환불 관련
     REFUND_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 환불ID입니다."),

--- a/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
+++ b/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
@@ -1,0 +1,273 @@
+package me.performancereservation.api;
+
+import me.performancereservation.domain.performance.entities.Performance;
+import me.performancereservation.domain.performance.entities.PerformanceSchedule;
+import me.performancereservation.domain.performance.enums.PerformanceCategory;
+import me.performancereservation.domain.performance.enums.PerformanceStatus;
+import me.performancereservation.domain.performance.repository.PerformanceRepository;
+import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.ReservationRepository;
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import me.performancereservation.domain.user.entitiy.User;
+import me.performancereservation.domain.user.enums.Role;
+import me.performancereservation.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class AdminReservationControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    PerformanceRepository performanceRepository;
+
+    @Autowired
+    PerformanceScheduleRepository performanceScheduleRepository;
+
+    @BeforeEach
+    void init() {
+        User user1 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자1")
+                        .email("user1@gmail.com")
+                        .phoneNumber("010-1111-1111")
+                        .build()
+        );
+        User user2 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자2")
+                        .email("user2@gmail.com")
+                        .phoneNumber("010-2222-2222")
+                        .build()
+        );
+        User user3 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자3")
+                        .email("user3@gmail.com")
+                        .phoneNumber("010-3333-3333")
+                        .build()
+        );
+        User user4 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자4")
+                        .email("user4@gmail.com")
+                        .phoneNumber("010-3333-3333")
+                        .build()
+        );
+
+        User manager = userRepository.save(
+                User.builder()
+                        .role(Role.MANAGER)
+                        .name("매니저")
+                        .email("manager@gmail.com")
+                        .phoneNumber("010-2345-2345")
+                        .build()
+        );
+
+        Performance performance = performanceRepository.save(
+                Performance.builder()
+                        .title("오페라 갈라")
+                        .venue("세종문화회관 대극장")
+                        .price(120000)
+                        .totalSeats(2000)
+                        .category(PerformanceCategory.OPERA)
+                        .performanceDate(LocalDateTime.of(2025, 12, 13, 0, 0))
+                        .description("한자리에서 만나는 오페라 명곡들 그리고 오페라 스타들!")
+                        .managerId(manager.getId())
+                        .status(PerformanceStatus.CONFIRMED)
+                        .build()
+        );
+
+        PerformanceSchedule schedule = performanceScheduleRepository.save(
+                PerformanceSchedule.builder()
+                        .performanceId(performance.getId())
+                        .startTime(LocalDateTime.of(2025, 12, 13, 9, 0))
+                        .endTime(LocalDateTime.of(2025, 12, 13, 10, 0))
+                        .remainingSeats(performance.getTotalSeats())
+                        .canceled(false)
+                        .build()
+        );
+
+        List<User> users = List.of(user1, user2, user3, user4);
+        for (int i = 0; i < 50; i++) {
+            ReservationStatus status = i % 2 == 0
+                    ? ReservationStatus.PAYMENTS_PENDING
+                    : ReservationStatus.PAYMENTS_CONFIRMED;
+
+
+            reservationRepository.save(
+                    Reservation.builder()
+                            .userId(users.get(i % users.size()).getId())
+                            .quantity((i % 4) + 1) // 1~4개
+                            .scheduleId(schedule.getId())
+                            .status(status)
+                            .build()
+            );
+        }
+    }
+
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getReservationListPaging_Success() throws Exception {
+        mockMvc.perform(get("/admin/reservations")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(10)) // 1페이지 10개
+                .andExpect(jsonPath("$.totalPages").value(5)) // 50 / 10 = 5페이지
+                .andExpect(jsonPath("$.totalElements").value(50)); // 총 50개
+    }
+
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByName_Success() throws Exception {
+        // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("userName", "사용자1")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(10)) // 1페이지 10개
+                .andExpect(jsonPath("$.totalElements").value(13)) // 총 13개
+                .andExpect(jsonPath("$.totalPages").value(2)); // 13 / 10 = 1.3 → 2페이지
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByName_Failure() throws Exception {
+        // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("userName", "없는 사용자")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(0))
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.totalPages").value(0));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByTitle_Success() throws Exception {
+        // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("performanceTitle", "오페라 갈라")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(10)) // 1페이지 10개
+                .andExpect(jsonPath("$.totalElements").value(50)) // 총 50개
+                .andExpect(jsonPath("$.totalPages").value(5)); // 50 / 10 = 5 → 5페이지
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByTitle_Failure() throws Exception {
+        // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("performanceTitle", "없는 공연")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(0))
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.totalPages").value(0));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByStatus_Success() throws Exception {
+        // PAYMENTS_PENDING: 50 / 2 = 25개
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("reservationStatus", "PAYMENTS_PENDING")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(10))
+                .andExpect(jsonPath("$.totalElements").value(25)) // 25개
+                .andExpect(jsonPath("$.totalPages").value(3)); // 25 / 10 = 2.5 → 3페이지
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByStatus_Failure() throws Exception {
+        // PAYMENTS_PENDING: 50 / 2 = 25개
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("reservationStatus", "CANCEL_PENDING")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(0))
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.totalPages").value(0));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByDate_Success() throws Exception {
+        // 1일 전 ~ 1일 후 (모든 예약 포함)
+        LocalDateTime start = LocalDateTime.now().minusDays(1).toLocalDate().atStartOfDay();
+        LocalDateTime end = LocalDateTime.now().plusDays(1).toLocalDate().atTime(23, 59, 59);
+
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("startDate", start.toString())
+                        .param("endDate", end.toString())
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(10))
+                .andExpect(jsonPath("$.totalElements").value(50)) // 전체 50개
+                .andExpect(jsonPath("$.totalPages").value(5));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void searchReservationByDate_Failure() throws Exception {
+        // 11일 전 ~ 10일 전 (예약 없음)
+        LocalDateTime start = LocalDateTime.now().minusDays(11).toLocalDate().atStartOfDay();
+        LocalDateTime end = LocalDateTime.now().minusDays(10).toLocalDate().atTime(23, 59, 59);
+
+        mockMvc.perform(get("/admin/reservations/search")
+                        .param("startDate", start.toString())
+                        .param("endDate", end.toString())
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(0))
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.totalPages").value(0));
+    }
+}
+
+

--- a/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
+++ b/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
@@ -24,8 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -48,6 +50,11 @@ class AdminReservationControllerTest {
 
     @Autowired
     PerformanceScheduleRepository performanceScheduleRepository;
+
+    User user5;
+    User user6;
+    User user7;
+    User user8;
 
     @BeforeEach
     void init() {
@@ -81,6 +88,38 @@ class AdminReservationControllerTest {
                         .name("사용자4")
                         .email("user4@gmail.com")
                         .phoneNumber("010-3333-3333")
+                        .build()
+        );
+        user5 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자5")
+                        .email("user5@gmail.com")
+                        .phoneNumber("010-5555-5555")
+                        .build()
+        );
+        user6 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자6")
+                        .email("user6@gmail.com")
+                        .phoneNumber("010-6666-6666")
+                        .build()
+        );
+        user7 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자7")
+                        .email("user7@gmail.com")
+                        .phoneNumber("010-7777-7777")
+                        .build()
+        );
+        user8 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자8")
+                        .email("user8@gmail.com")
+                        .phoneNumber("010-8888-8888")
                         .build()
         );
 
@@ -133,6 +172,40 @@ class AdminReservationControllerTest {
                             .build()
             );
         }
+
+        reservationRepository.save(
+                Reservation.builder()
+                        .userId(user5.getId())
+                        .quantity(2)
+                        .scheduleId(schedule.getId())
+                        .status(ReservationStatus.PAYMENTS_PENDING)
+                        .build()
+        );
+        reservationRepository.save(
+                Reservation.builder()
+                        .userId(user6.getId())
+                        .quantity(1)
+                        .scheduleId(schedule.getId())
+                        .status(ReservationStatus.PAYMENTS_CONFIRMED)
+                        .build()
+        );
+        reservationRepository.save(
+                Reservation.builder()
+                        .userId(user7.getId())
+                        .quantity(1)
+                        .scheduleId(schedule.getId())
+                        .status(ReservationStatus.PAYMENTS_PENDING)
+                        .build()
+        );
+
+        reservationRepository.save(
+                Reservation.builder()
+                        .userId(user8.getId())
+                        .quantity(1)
+                        .scheduleId(schedule.getId())
+                        .status(ReservationStatus.PAYMENTS_PENDING)
+                        .build()
+        );
     }
 
 
@@ -144,8 +217,8 @@ class AdminReservationControllerTest {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10)) // 1페이지 10개
-                .andExpect(jsonPath("$.totalPages").value(5)) // 50 / 10 = 5페이지
-                .andExpect(jsonPath("$.totalElements").value(50)); // 총 50개
+                .andExpect(jsonPath("$.totalPages").value(6)) // 54 / 10 = 5.4 -> 6페이지
+                .andExpect(jsonPath("$.totalElements").value(54)); // 총 50개
     }
 
 
@@ -187,8 +260,8 @@ class AdminReservationControllerTest {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10)) // 1페이지 10개
-                .andExpect(jsonPath("$.totalElements").value(50)) // 총 50개
-                .andExpect(jsonPath("$.totalPages").value(5)); // 50 / 10 = 5 → 5페이지
+                .andExpect(jsonPath("$.totalElements").value(54)) // 총 50개
+                .andExpect(jsonPath("$.totalPages").value(6)); // 54 / 10 = 5.4 → 6페이지
     }
 
     @Test
@@ -207,7 +280,7 @@ class AdminReservationControllerTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
-    void searchReservationByStatus_Success() throws Exception {
+    void searchReservationByStatus_PAYMENT_PENDING() throws Exception {
         // PAYMENTS_PENDING: 50 / 2 = 25개
         mockMvc.perform(get("/admin/reservations/search")
                         .param("reservationStatus", "PAYMENTS_PENDING")
@@ -215,22 +288,22 @@ class AdminReservationControllerTest {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10))
-                .andExpect(jsonPath("$.totalElements").value(25)) // 25개
-                .andExpect(jsonPath("$.totalPages").value(3)); // 25 / 10 = 2.5 → 3페이지
+                .andExpect(jsonPath("$.totalElements").value(26)) // 25개
+                .andExpect(jsonPath("$.totalPages").value(3)); // 26 / 10 = 2.6 → 3페이지
     }
 
     @Test
     @WithMockUser(roles = "ADMIN")
-    void searchReservationByStatus_Failure() throws Exception {
+    void searchReservationByStatus_CANCELPENDING() throws Exception {
         // PAYMENTS_PENDING: 50 / 2 = 25개
         mockMvc.perform(get("/admin/reservations/search")
                         .param("reservationStatus", "CANCEL_PENDING")
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content.size()").value(0))
-                .andExpect(jsonPath("$.totalElements").value(0))
-                .andExpect(jsonPath("$.totalPages").value(0));
+                .andExpect(jsonPath("$.content.size()").value(1))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1));
     }
 
     @Test
@@ -247,8 +320,8 @@ class AdminReservationControllerTest {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10))
-                .andExpect(jsonPath("$.totalElements").value(50)) // 전체 50개
-                .andExpect(jsonPath("$.totalPages").value(5));
+                .andExpect(jsonPath("$.totalElements").value(54)) // 전체 50개
+                .andExpect(jsonPath("$.totalPages").value(6));
     }
 
     @Test
@@ -268,6 +341,60 @@ class AdminReservationControllerTest {
                 .andExpect(jsonPath("$.totalElements").value(0))
                 .andExpect(jsonPath("$.totalPages").value(0));
     }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void confirmReservation_Success() throws Exception {
+        // 펜딩 상태 예약 확정 성공
+        Reservation pending = reservationRepository.findById(user5.getId()).get();
+
+        mockMvc.perform(patch("/admin/reservations/" + pending.getId())
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        PerformanceSchedule schedule = performanceScheduleRepository.findById(pending.getScheduleId()).get();
+        Performance performance = performanceRepository.findById(schedule.getPerformanceId()).get();
+
+        // 상태가 확정으로 변경되었는지 확인
+        Reservation updated = reservationRepository.findById(pending.getId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(ReservationStatus.PAYMENTS_CONFIRMED);
+        // 좌석 차감 확인
+        assertThat(schedule.getRemainingSeats()).isEqualTo(performance.getTotalSeats() - pending.getQuantity());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void confirmReservationAlreadyConfirmed_Failure() throws Exception {
+        // 이미 확정된 예약에 대해 확정 요청 시 409 CONFLICT
+        Reservation confirmed = reservationRepository.findById(user6.getId()).get();
+
+        mockMvc.perform(patch("/admin/reservations/" + confirmed.getId())
+                        .with(csrf()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 확정된 예약입니다."));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void confirmReservationCanceledStatus_Failure() throws Exception {
+        // 취소 상태 예약에 대해 확정 요청 시 400 BAD_REQUEST
+        Reservation cancelPending = reservationRepository.findById(user7.getId()).get();
+        cancelPending.requestCancel();
+
+        mockMvc.perform(patch("/admin/reservations/" + cancelPending.getId())
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("유효하지 않은 예약 상태입니다."));
+
+        Reservation cancelConfirmed = reservationRepository.findById(user8.getId()).get();
+        cancelConfirmed.cancelConfirm();
+
+        mockMvc.perform(patch("/admin/reservations/" + cancelConfirmed.getId())
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("유효하지 않은 예약 상태입니다."));
+    }
+
 }
 
 

--- a/backend/src/test/java/me/performancereservation/domain/performance/service/PerformanceServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/performance/service/PerformanceServiceTest.java
@@ -5,8 +5,8 @@ import me.performancereservation.domain.file.FileRepository;
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceCreateRequest;
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceUpdateRequest;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceDetailResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceListResponse;
-import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerListResponse;
+import me.performancereservation.domain.performance.dto.performance.response.PerformancePageResponse;
+import me.performancereservation.domain.performance.dto.performance.response.PerformanceManagerPageResponse;
 import me.performancereservation.domain.performance.entities.Performance;
 import me.performancereservation.domain.performance.entities.PerformanceSchedule;
 import me.performancereservation.domain.performance.enums.PerformanceCategory;
@@ -359,7 +359,7 @@ class PerformanceServiceTest {
         when(fileRepository.findAllById(List.of(FILE_ID1, FILE_ID2, FILE_ID3))).thenReturn(List.of(file1, file2, file3));
 
         //when
-        Page<PerformanceManagerListResponse> response = performanceService.getPerformanceManagerList(Pageable.unpaged(), MANAGER_ID);
+        Page<PerformanceManagerPageResponse> response = performanceService.getPerformanceManagerList(Pageable.unpaged(), MANAGER_ID);
 
         //then
         assertThat(response.getContent()).hasSize(3);
@@ -375,12 +375,12 @@ class PerformanceServiceTest {
         when(performanceRepository.findAvailablePerformances(Pageable.unpaged())).thenReturn(page);
 
         //when
-        Page<PerformanceListResponse> response = performanceService.getPerformanceList(Pageable.unpaged());
+        Page<PerformancePageResponse> response = performanceService.getPerformanceList(Pageable.unpaged());
 
         //then
         assertThat(response.getContent()).hasSize(2);
         assertThat(response.getContent())
-                .extracting(PerformanceListResponse::id)
+                .extracting(PerformancePageResponse::id)
                 .doesNotContain(PERFORMANCE_ID3);
     }
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
```
📁api
 └─ AdminReservationController.java     // 어드민 예약 관련 처리 컨트롤러

📁admin
 ├─📁dto
 │   ├─ AdminReservationPageResponse.java   // 예약 목록 페이징 반환 응답 dto
 ├─📁repository      
 │   └─ AdminReservationRepository.java     // 예약 목록 죄회를 위한 쿼리 리포지토리
 └─📁servie
     └─ AdminReservationRepository.java     // 예약 관련 로직을 수행하는 서비스

📁global
 └─📁exeption
     └─ ErrorCode.java  // 에러코드 추가
```

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [x] 주석 추가 및 수정
-   [ ] 문서 수정
-   [x] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

### 응답 구성 
예약 목록을 리스트 or 테이블 형태로 응답을 내려줬을 때 넘겨주는 정보 외 추가 적인 상세 정보는 필요하지 않다고 생각하여 상세 페이지 없이 구현해봤습니다.

### 관리자 예약 목록 테이블 예시

| 예약 ID | 회차 ID | 예약자명 | 공연 제목              | 티켓 가격 | 수량 | 상태               | 예약 일시           | 액션           |
|---------|---------|----------|------------------------|-----------|------|--------------------|---------------------|----------------|
| 1001    | 2001    | 김철수   | 오페라 갈라     | 120,000   | 2    | PAYMENTS_PENDING   | 2025-12-13T09:00    | [예약 확정]    |
| 1002    | 2002    | 이영희   | 오페라 갈라     | 120,000   | 1    | PAYMENTS_CONFIRMED | 2025-12-13T14:00    |                |
| 1003    | 2003    | 박민수   | 오페라 갈라     | 120,000   | 3    | PAYMENTS_PENDING   | 2025-12-13T19:00    | [예약 확정]    |

위 예시처럼 응답 정보 옆 대기 상태의 예약에 확정 버튼을 두어 상세 페이지 열람 없이 처리하는 방식이 간편하다고 생각했습니다. 

### 검색 기능
검색을 간단하게 Like를 사용해 널널하게 포함된 결과를 가져오게 처리했고 혹시나 공연 제목이 영어일 경우를 생각해 대소문자 구분 없이 검사가 가능하게 하였습니다. 
```sql
    WHERE 
        (:userName IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :userName, '%'))) 
        AND (:performanceTitle IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :performanceTitle, '%')))
```
기본적인 검색 구조는 관리자가 고객 이름, 공연 제목 둘 중 하나를 입력하여 검색을 하게 되고 추가 필터로 예약 상태, 날짜를 사용할 수 있도록 구현했습니다.
```sql
        AND (:reservationStatus IS NULL OR r.status = :reservationStatus)
        AND (:startDate IS NULL OR r.createdAt >= :startDate)
        AND (:endDate IS NULL OR r.createdAt <= :endDate)
```

일단 저는 상세 페이지에 보여줄 만큼의 추가 정보가 더 없다고 생각해 이렇게 구현해 봤는데 어떻게 생각하시나요?
## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
