### PR TITLE
feat(reservation): 유저 예약 조회 기능 구현 (상세 조회, 목록 조회)

### DIFF
--- a/backend/src/main/java/me/performancereservation/api/ReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/ReservationController.java
@@ -2,9 +2,15 @@ package me.performancereservation.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import me.performancereservation.domain.reservation.dto.ReservationListResponse;
+import me.performancereservation.domain.reservation.service.ReservationQueryService;
 import me.performancereservation.domain.reservation.service.redis.RedisSeatReservationService;
 import me.performancereservation.domain.reservation.dto.ReservationRequest;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,7 +19,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/reservations")
 @RequiredArgsConstructor
 public class ReservationController {
-    private final RedisSeatReservationService reservationService;
+    private final RedisSeatReservationService seatReservationService;
+    private final ReservationQueryService reservationQueryService;
 
     @PostMapping
     public ResponseEntity<ReservationResponse> reserve(
@@ -27,7 +34,7 @@ public class ReservationController {
 //                request.quantity()
 //        );
 
-        ReservationResponse result = reservationService.reserve(
+        ReservationResponse result = seatReservationService.reserve(
                 request.scheduleId(),
                 request.userId(),
                 request.quantity()
@@ -41,12 +48,37 @@ public class ReservationController {
             @PathVariable Long reservationId
             // @AuthenticationPrincipal Authentication authentication // TODO Authentication 머지 되면 수정 예정
     ) {
-        reservationService.cancel(
+        seatReservationService.cancel(
                 reservationId,
                 1L // TODO 수정 예정
                 // authentication.userId() // TODO Authentication 머지 되면 수정 예정
         ) ;
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<Page<ReservationListResponse>> getUserReservations(
+//            @AuthenticationPrincipal JwtAuthentication authentication,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<ReservationListResponse> result = reservationQueryService.getAllByUserId(
+//                authentication.userId(), // TODO Authentication 머지 되면 수정 예정
+                1L, // TODO 수정 예정
+                pageable
+        );
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/me/{reservationId}")
+    public ResponseEntity<ReservationResponse> getReservationById(
+//            @AuthenticationPrincipal JwtAuthentication authentication,
+            @PathVariable Long reservationId
+    ) {
+        return ResponseEntity.ok(reservationQueryService.getByReservationId(
+                reservationId,
+//                authentication.userId() // TODO Authentication 머지 되면 수정 예정
+                1L // TODO 수정 예정
+        ));
     }
 }

--- a/backend/src/main/java/me/performancereservation/api/ReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/ReservationController.java
@@ -2,7 +2,7 @@ package me.performancereservation.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import me.performancereservation.domain.reservation.dto.ReservationListResponse;
+import me.performancereservation.domain.reservation.dto.ReservationPageResponse;
 import me.performancereservation.domain.reservation.service.ReservationQueryService;
 import me.performancereservation.domain.reservation.service.redis.RedisSeatReservationService;
 import me.performancereservation.domain.reservation.dto.ReservationRequest;
@@ -58,10 +58,10 @@ public class ReservationController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<Page<ReservationListResponse>> getUserReservations(
+    public ResponseEntity<Page<ReservationPageResponse>> getUserReservations(
 //            @AuthenticationPrincipal JwtAuthentication authentication,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<ReservationListResponse> result = reservationQueryService.getAllByUserId(
+        Page<ReservationPageResponse> result = reservationQueryService.getAllByUserId(
 //                authentication.userId(), // TODO Authentication 머지 되면 수정 예정
                 1L, // TODO 수정 예정
                 pageable

--- a/backend/src/main/java/me/performancereservation/api/ReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/ReservationController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.reservation.dto.ReservationPageResponse;
 import me.performancereservation.domain.reservation.service.ReservationQueryService;
+import me.performancereservation.domain.reservation.service.redis.RedisReservationBulkCancelService;
 import me.performancereservation.domain.reservation.service.redis.RedisSeatReservationService;
 import me.performancereservation.domain.reservation.dto.ReservationRequest;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ReservationController {
     private final RedisSeatReservationService seatReservationService;
+    private final RedisReservationBulkCancelService bulkCancelService;
     private final ReservationQueryService reservationQueryService;
 
     @PostMapping
@@ -80,5 +82,14 @@ public class ReservationController {
 //                authentication.userId() // TODO Authentication 머지 되면 수정 예정
                 1L // TODO 수정 예정
         ));
+    }
+
+    // 공연 ID 기준으로 예약 일괄 취소를 수동으로 수행
+    @PostMapping("/cancel/{performanceId}")
+    // TODO 어드민 권한 부착하거나 어드민 컨트롤러 구현되면 그쪽으로 이동
+    public ResponseEntity<Void> bulkCancelByPerformanceId(@PathVariable Long performanceId) {
+        bulkCancelService.cancelAllByPerformanceId(performanceId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/entities/PerformanceSchedule.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/entities/PerformanceSchedule.java
@@ -39,9 +39,6 @@ public class PerformanceSchedule extends BaseEntity {
     }
 
     public void cancel() {
-        if (this.canceled) {
-            throw ErrorCode.SCHEDULE_ALREADY_CANCELED.domainException("이미 취소된 회차입니다. id = " + this.id);
-        }
         this.canceled = true;
     }
 

--- a/backend/src/main/java/me/performancereservation/domain/performance/event/PerformanceCanceledEvent.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/event/PerformanceCanceledEvent.java
@@ -1,0 +1,8 @@
+package me.performancereservation.domain.performance.event;
+
+/**
+ * 공연이 취소됐을 때, 공연 취소 이벤트리스너에게 전송할 이벤트 파라미터
+ *
+ * @param performanceId 취소된 공연의 id
+ */
+public record PerformanceCanceledEvent(Long performanceId) { }

--- a/backend/src/main/java/me/performancereservation/domain/performance/event/ScheduleCanceledEvent.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/event/ScheduleCanceledEvent.java
@@ -1,0 +1,3 @@
+package me.performancereservation.domain.performance.event;
+
+public record ScheduleCanceledEvent(Long scheduleId) {}

--- a/backend/src/main/java/me/performancereservation/domain/performance/event/ScheduleCanceledEvent.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/event/ScheduleCanceledEvent.java
@@ -1,3 +1,8 @@
 package me.performancereservation.domain.performance.event;
 
+/**
+ * 특정 공연 회차가 취소됐을 때, 공연 회차 취소 이벤트리스너에게 전송할 이벤트 파라미터
+ *
+ * @param scheduleId 취소된 공연 회차의 id
+ */
 public record ScheduleCanceledEvent(Long scheduleId) {}

--- a/backend/src/main/java/me/performancereservation/domain/performance/repository/PerformanceScheduleRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/repository/PerformanceScheduleRepository.java
@@ -23,6 +23,18 @@ public interface PerformanceScheduleRepository extends JpaRepository<Performance
     """)
     Optional<SchedulePerformanceInfo> findSchedulePerformanceInfoByScheduleId(@Param("scheduleId") Long scheduleId);
 
+    // scheduleId로 DTO 프로젝션을 이용해서 in절로 SchedulePerformanceInfo 데이터 모델 리스트를 조회
+    @Query("""
+    SELECT new me.performancereservation.domain.performance.model.SchedulePerformanceInfo(
+        p.id, p.title, p.venue, p.price,
+        ps.id, ps.startTime, ps.endTime
+    )
+    FROM PerformanceSchedule ps
+    JOIN Performance p ON ps.performanceId = p.id
+    WHERE ps.id IN :scheduleIds
+    """)
+    List<SchedulePerformanceInfo> findAllSchedulePerformanceInfoByScheduleIds(@Param("scheduleIds") List<Long> scheduleIds);
+
     // 공연 아이디로 모든 회차 가져오기
     List<PerformanceSchedule> findByPerformanceId(Long id);
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/repository/PerformanceScheduleRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/repository/PerformanceScheduleRepository.java
@@ -25,15 +25,23 @@ public interface PerformanceScheduleRepository extends JpaRepository<Performance
 
     // scheduleId로 DTO 프로젝션을 이용해서 in절로 SchedulePerformanceInfo 데이터 모델 리스트를 조회
     @Query("""
-    SELECT new me.performancereservation.domain.performance.model.SchedulePerformanceInfo(
-        p.id, p.title, p.venue, p.price,
-        ps.id, ps.startTime, ps.endTime
-    )
-    FROM PerformanceSchedule ps
-    JOIN Performance p ON ps.performanceId = p.id
-    WHERE ps.id IN :scheduleIds
+        SELECT new me.performancereservation.domain.performance.model.SchedulePerformanceInfo(
+            p.id, p.title, p.venue, p.price,
+            ps.id, ps.startTime, ps.endTime
+        )
+        FROM PerformanceSchedule ps
+        JOIN Performance p ON ps.performanceId = p.id
+        WHERE ps.id IN :scheduleIds
     """)
     List<SchedulePerformanceInfo> findAllSchedulePerformanceInfoByScheduleIds(@Param("scheduleIds") List<Long> scheduleIds);
+
+    // performanceId로 모든 회차 id 조회
+    @Query("""
+        SELECT ps.id
+        FROM PerformanceSchedule ps
+        WHERE ps.performanceId = :performanceId
+    """)
+    List<Long> findIdsByPerformanceId(@Param("performanceId") Long performanceId);
 
     // 공연 아이디로 모든 회차 가져오기
     List<PerformanceSchedule> findByPerformanceId(Long id);

--- a/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
@@ -10,14 +10,19 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-    /**
-     * 예약 id들과 예약 상태를 조건으로 해당하는 예약들을 조회
-     */
+    // 예약 id들과 예약 상태를 조건으로 해당하는 예약들을 조회
     @Query("""
         SELECT r FROM Reservation r
         WHERE r.id IN :ids AND r.status = :status
     """)
     List<Reservation> findAllByIdsAndStatus(@Param("ids") List<Long> ids, @Param("status") ReservationStatus status);
+
+    // 공연 회차 id 들로 예약 리스트 조회
+    @Query("""
+        SELECT r FROM Reservation r
+        WHERE r.scheduleId IN :scheduleIds
+    """)
+    List<Reservation> findAllByScheduleIds(@Param("scheduleIds") List<Long> scheduleIds);
 
     Page<Reservation> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
@@ -24,5 +24,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     """)
     List<Reservation> findAllByScheduleIds(@Param("scheduleIds") List<Long> scheduleIds);
 
+    List<Reservation> findAllByScheduleId(Long scheduleId);
+
     Page<Reservation> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
@@ -1,6 +1,8 @@
 package me.performancereservation.domain.reservation;
 
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,8 +10,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-
-
     /**
      * 예약 id들과 예약 상태를 조건으로 해당하는 예약들을 조회
      */
@@ -18,4 +18,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         WHERE r.id IN :ids AND r.status = :status
     """)
     List<Reservation> findAllByIdsAndStatus(@Param("ids") List<Long> ids, @Param("status") ReservationStatus status);
+
+    Page<Reservation> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationListResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationListResponse.java
@@ -1,0 +1,24 @@
+package me.performancereservation.domain.reservation.dto;
+
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * 예약 목록 조회용 응답 Dto
+ */
+public record ReservationListResponse(
+        // Reservation
+        Long reservationId, // 예약 ID
+        int quantity, // 티켓 수량
+        ReservationStatus status, // 예약 상태
+        LocalDateTime createdAt, // 예약 일시
+
+        // Performance
+        String title, // 공역 제목
+        String venue, // 공연 장소
+        int ticketPrice, // 티켓 가격
+
+        // Calculated value
+        int totalPrice // 총 결제 금액
+) {}

--- a/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationPageResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 /**
  * 예약 목록 조회용 응답 Dto
  */
-public record ReservationListResponse(
+public record ReservationPageResponse(
         // Reservation
         Long reservationId, // 예약 ID
         int quantity, // 티켓 수량

--- a/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
@@ -43,6 +43,7 @@ public class ReservationMapper {
     }
 
     /**
+     * 예약 객체와 공연+공연회차 데이터 모델 객체를 이용해 예약 응답 Dto Page 생성
      *
      * @param reservation 예약 객체
      * @param schedulePerformanceInfo 공연+공연회차 데이터 모델 객체

--- a/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
@@ -3,6 +3,7 @@ package me.performancereservation.domain.reservation.mapper;
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.performance.model.SchedulePerformanceInfo;
 import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.dto.ReservationListResponse;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -36,6 +37,29 @@ public class ReservationMapper {
                 reservation.getStatus(),
                 createdAt,
                 expirationAt,
+                schedulePerformanceInfo.price(),
+                totalPrice
+        );
+    }
+
+    /**
+     *
+     * @param reservation 예약 객체
+     * @param schedulePerformanceInfo 공연+공연회차 데이터 모델 객체
+     * @return ReservationListResponse 예약 목록 응답 dto
+     */
+    public ReservationListResponse toListResponseDto(Reservation reservation, SchedulePerformanceInfo schedulePerformanceInfo) {
+        LocalDateTime createdAt = reservation.getCreatedAt();
+
+        int totalPrice = reservation.calculateTotalPrice(schedulePerformanceInfo.price());
+
+        return new ReservationListResponse(
+                reservation.getId(),
+                reservation.getQuantity(),
+                reservation.getStatus(),
+                createdAt,
+                schedulePerformanceInfo.title(),
+                schedulePerformanceInfo.venue(),
                 schedulePerformanceInfo.price(),
                 totalPrice
         );

--- a/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
@@ -3,7 +3,7 @@ package me.performancereservation.domain.reservation.mapper;
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.performance.model.SchedulePerformanceInfo;
 import me.performancereservation.domain.reservation.Reservation;
-import me.performancereservation.domain.reservation.dto.ReservationListResponse;
+import me.performancereservation.domain.reservation.dto.ReservationPageResponse;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -48,12 +48,12 @@ public class ReservationMapper {
      * @param schedulePerformanceInfo 공연+공연회차 데이터 모델 객체
      * @return ReservationListResponse 예약 목록 응답 dto
      */
-    public ReservationListResponse toListResponseDto(Reservation reservation, SchedulePerformanceInfo schedulePerformanceInfo) {
+    public ReservationPageResponse toListResponseDto(Reservation reservation, SchedulePerformanceInfo schedulePerformanceInfo) {
         LocalDateTime createdAt = reservation.getCreatedAt();
 
         int totalPrice = reservation.calculateTotalPrice(schedulePerformanceInfo.price());
 
-        return new ReservationListResponse(
+        return new ReservationPageResponse(
                 reservation.getId(),
                 reservation.getQuantity(),
                 reservation.getStatus(),

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationEventListener.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationEventListener.java
@@ -1,0 +1,28 @@
+package me.performancereservation.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import me.performancereservation.domain.performance.event.PerformanceCanceledEvent;
+import me.performancereservation.domain.reservation.service.redis.RedisReservationBulkCancelService;
+import me.performancereservation.domain.reservation.service.redis.RedisSeatReservationService;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationEventListener {
+
+    private final RedisReservationBulkCancelService redisReservationBulkCancelService;
+
+    /**
+     * 공연이 취소됐을 때 발생하는 이벤트를 핸들링하는 리스너
+     * 취소된 공연에 대한 예약들을 백그라운드에서 일괄 취소 처리함
+     *
+     * @param event 공연취소 이벤트 (performanceId)
+     */
+    @Async
+    @EventListener
+    public void handlePerformanceCanceled(PerformanceCanceledEvent event) {
+        redisReservationBulkCancelService.cancelAllByPerformanceId(event.performanceId());
+    }
+}

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationEventListener.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationEventListener.java
@@ -2,6 +2,7 @@ package me.performancereservation.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.performance.event.PerformanceCanceledEvent;
+import me.performancereservation.domain.performance.event.ScheduleCanceledEvent;
 import me.performancereservation.domain.reservation.service.redis.RedisReservationBulkCancelService;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -23,5 +24,17 @@ public class ReservationEventListener {
     @EventListener
     public void handlePerformanceCanceled(PerformanceCanceledEvent event) {
         reservationBulkCancelService.cancelAllByPerformanceId(event.performanceId());
+    }
+
+    /**
+     * 공연 회차가 취소됐을 때 발생하는 이벤트를 핸들링하는 리스너
+     * 취소된 공연회차에 대한 예약들을 백그라운드에서 일괄 취소 처리함
+     *
+     * @param event 공연 회차 취소 이벤트 (scheduleId)
+     */
+    @Async
+    @EventListener
+    public void handleScheduleCanceled(ScheduleCanceledEvent event) {
+        reservationBulkCancelService.cancelAllByScheduleId(event.scheduleId());
     }
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationEventListener.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationEventListener.java
@@ -3,7 +3,6 @@ package me.performancereservation.domain.reservation.service;
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.performance.event.PerformanceCanceledEvent;
 import me.performancereservation.domain.reservation.service.redis.RedisReservationBulkCancelService;
-import me.performancereservation.domain.reservation.service.redis.RedisSeatReservationService;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -12,7 +11,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ReservationEventListener {
 
-    private final RedisReservationBulkCancelService redisReservationBulkCancelService;
+    private final RedisReservationBulkCancelService reservationBulkCancelService;
 
     /**
      * 공연이 취소됐을 때 발생하는 이벤트를 핸들링하는 리스너
@@ -23,6 +22,6 @@ public class ReservationEventListener {
     @Async
     @EventListener
     public void handlePerformanceCanceled(PerformanceCanceledEvent event) {
-        redisReservationBulkCancelService.cancelAllByPerformanceId(event.performanceId());
+        reservationBulkCancelService.cancelAllByPerformanceId(event.performanceId());
     }
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationQueryService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationQueryService.java
@@ -1,0 +1,87 @@
+package me.performancereservation.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import me.performancereservation.domain.performance.model.SchedulePerformanceInfo;
+import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.ReservationRepository;
+import me.performancereservation.domain.reservation.dto.ReservationListResponse;
+import me.performancereservation.domain.reservation.dto.ReservationResponse;
+import me.performancereservation.domain.reservation.mapper.ReservationMapper;
+import me.performancereservation.global.exception.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationQueryService {
+    private final ReservationRepository reservationRepository;
+    private final PerformanceScheduleRepository performanceScheduleRepository;
+
+    private final ReservationMapper reservationMapper;
+
+    /**
+     * 유저 id로 본인의 예약 정보를 전부 조회
+     *
+     * @param userId 유저 ID
+     * @return 페이지네이션된 ReservationListResponse
+     */
+    @Transactional(readOnly = true)
+    public Page<ReservationListResponse> getAllByUserId(Long userId, Pageable pageable) {
+        // 본인의 모든 예약 목록 조회
+        Page<Reservation> reservations = reservationRepository.findAllByUserId(userId, pageable);
+
+        // 공연 회차 ID 리스트 수집
+        List<Long> scheduleIds = reservations.stream()
+                .map(Reservation::getScheduleId)
+                .toList();
+
+        // in절로 SchedulePerformanceInfo 리스트 조회
+        List<SchedulePerformanceInfo> scheduleInfos = performanceScheduleRepository.findAllSchedulePerformanceInfoByScheduleIds(scheduleIds);
+
+        Map<Long, SchedulePerformanceInfo> infoMap = scheduleInfos.stream()
+                .collect(Collectors.toMap(SchedulePerformanceInfo::scheduleId, sp -> sp));
+
+        // Page<ReservationListResponseDto>로 매핑
+        return reservations.map(reservation -> mapToResponse(reservation, infoMap));
+    }
+
+    // ReservationListResponseDto로 매핑 (가독성을 위해 map 로직 추출)
+    private ReservationListResponse mapToResponse(Reservation reservation, Map<Long, SchedulePerformanceInfo> infoMap) {
+        SchedulePerformanceInfo schedulePerformanceInfo = infoMap.get(reservation.getScheduleId());
+
+        return reservationMapper.toListResponseDto(reservation, schedulePerformanceInfo);
+    }
+
+    /**
+     * 예약 id로 본인의 상세 예약 정보 조회
+     *
+     * @param reservationId 예약 ID
+     * @param userId 로그인한 사용자의 ID
+     * @return ReservationResponse
+     */
+    @Transactional(readOnly = true)
+    public ReservationResponse getByReservationId(Long reservationId, Long userId) {
+        // 본인의 예약 조회
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> ErrorCode.RESERVATION_NOT_FOUND.persistenceException("예약 ID: " + reservationId));
+
+        // 본인의 예약이 아니면 예외
+        if (!reservation.getUserId().equals(userId)) {
+            throw ErrorCode.PERMISSION_DENIED.serviceException("해당 예약에 접근할 수 없습니다.");
+        }
+
+        // SchedulePerformanceInfo 조회
+        SchedulePerformanceInfo scheduleInfo = performanceScheduleRepository.findSchedulePerformanceInfoByScheduleId(reservation.getScheduleId())
+                .orElseThrow(() -> ErrorCode.PERFORMANCE_SCHEDULE_NOT_FOUND.persistenceException("공연 회차 ID: " + reservation.getId()));
+
+        // ReservationResponseDto 매핑
+        return reservationMapper.toResponseDto(reservation, scheduleInfo);
+    }
+}

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationQueryService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationQueryService.java
@@ -5,7 +5,7 @@ import me.performancereservation.domain.performance.model.SchedulePerformanceInf
 import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
 import me.performancereservation.domain.reservation.Reservation;
 import me.performancereservation.domain.reservation.ReservationRepository;
-import me.performancereservation.domain.reservation.dto.ReservationListResponse;
+import me.performancereservation.domain.reservation.dto.ReservationPageResponse;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
 import me.performancereservation.domain.reservation.mapper.ReservationMapper;
 import me.performancereservation.global.exception.ErrorCode;
@@ -33,7 +33,7 @@ public class ReservationQueryService {
      * @return 페이지네이션된 ReservationListResponse
      */
     @Transactional(readOnly = true)
-    public Page<ReservationListResponse> getAllByUserId(Long userId, Pageable pageable) {
+    public Page<ReservationPageResponse> getAllByUserId(Long userId, Pageable pageable) {
         // 본인의 모든 예약 목록 조회
         Page<Reservation> reservations = reservationRepository.findAllByUserId(userId, pageable);
 
@@ -53,7 +53,7 @@ public class ReservationQueryService {
     }
 
     // ReservationListResponseDto로 매핑 (가독성을 위해 map 로직 추출)
-    private ReservationListResponse mapToResponse(Reservation reservation, Map<Long, SchedulePerformanceInfo> infoMap) {
+    private ReservationPageResponse mapToResponse(Reservation reservation, Map<Long, SchedulePerformanceInfo> infoMap) {
         SchedulePerformanceInfo schedulePerformanceInfo = infoMap.get(reservation.getScheduleId());
 
         return reservationMapper.toListResponseDto(reservation, schedulePerformanceInfo);

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationQueryService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/ReservationQueryService.java
@@ -70,7 +70,7 @@ public class ReservationQueryService {
     public ReservationResponse getByReservationId(Long reservationId, Long userId) {
         // 본인의 예약 조회
         Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> ErrorCode.RESERVATION_NOT_FOUND.persistenceException("예약 ID: " + reservationId));
+                .orElseThrow(() -> ErrorCode.RESERVATION_NOT_FOUND.domainException("예약 ID: " + reservationId));
 
         // 본인의 예약이 아니면 예외
         if (!reservation.getUserId().equals(userId)) {
@@ -79,7 +79,7 @@ public class ReservationQueryService {
 
         // SchedulePerformanceInfo 조회
         SchedulePerformanceInfo scheduleInfo = performanceScheduleRepository.findSchedulePerformanceInfoByScheduleId(reservation.getScheduleId())
-                .orElseThrow(() -> ErrorCode.PERFORMANCE_SCHEDULE_NOT_FOUND.persistenceException("공연 회차 ID: " + reservation.getId()));
+                .orElseThrow(() -> ErrorCode.PERFORMANCE_SCHEDULE_NOT_FOUND.domainException("공연 회차 ID: " + reservation.getScheduleId()));
 
         // ReservationResponseDto 매핑
         return reservationMapper.toResponseDto(reservation, scheduleInfo);

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
@@ -1,0 +1,51 @@
+package me.performancereservation.domain.reservation.service.redis;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.ReservationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 자동/수동 예약 일괄 취소 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisReservationBulkCancelService {
+    private final PerformanceScheduleRepository performanceScheduleRepository;
+    private final ReservationRepository reservationRepository;
+
+    private final RedisReservationCancelExecutor redisReservationCancelExecutor;
+
+    /**
+     * 공연 id를 기반으로 해당 공연에 대한 예약들을 일괄 취소
+     * TODO 현재 실질적인 벌크처리는 안되고 있음
+     *      만약 공연취소로 인한 이벤트가 발생해서 이 메서드가 실행되는 경우엔, 백그라운드에서 동작하기때문에 상관없지만
+     *      수동으로 호출하는 경우엔, 사용자 경험이 안좋을 수 있음 (mvp 구현 목적으로 추후 벌크 update 방식으로 리팩토링 예정)
+     *
+     * @param performanceId 취소된 공연 id
+     */
+    @Transactional
+    public void cancelAllByPerformanceId(Long performanceId) {
+        log.info("[공연 일괄 취소] 공연 id: {}", performanceId);
+
+        // 취소된 공연의 모든 회차 id 조회
+        List<Long> scheduleIds = performanceScheduleRepository.findIdsByPerformanceId(performanceId);
+
+        // 회차별 예약 목록 조회
+        List<Reservation> reservations = reservationRepository.findAllByScheduleIds(scheduleIds);
+
+        for (Reservation reservation : reservations) {
+            // 이미 취소된 예약은 패스
+            if (reservation.isAlreadyCanceled()) return;
+
+            // 예약 취소 처리
+            redisReservationCancelExecutor.execute(reservation);
+        }
+    }
+}

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
@@ -3,9 +3,11 @@ package me.performancereservation.domain.reservation.service.redis;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.performancereservation.domain.performance.entities.PerformanceSchedule;
 import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
 import me.performancereservation.domain.reservation.Reservation;
 import me.performancereservation.domain.reservation.ReservationRepository;
+import me.performancereservation.global.storage.redis.RedisSeatService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,6 +19,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class RedisReservationBulkCancelService {
+    private final RedisSeatService redisSeatService;
+
     private final PerformanceScheduleRepository performanceScheduleRepository;
     private final ReservationRepository reservationRepository;
 
@@ -36,16 +40,26 @@ public class RedisReservationBulkCancelService {
 
         // 취소된 공연의 모든 회차 id 조회
         List<Long> scheduleIds = performanceScheduleRepository.findIdsByPerformanceId(performanceId);
+        
+        // 공연 일정이 없으면 패스
+        if (scheduleIds.isEmpty()) return;
 
         // 회차별 예약 목록 조회
         List<Reservation> reservations = reservationRepository.findAllByScheduleIds(scheduleIds);
+        
+        // 예약이 없으면 패스
+        if (reservations.isEmpty()) return;
 
+        // 레디스 좌석 정보 제거 및 예약 취소 처리
         for (Reservation reservation : reservations) {
             // 이미 취소된 예약은 패스
             if (reservation.isAlreadyCanceled()) continue;
 
+            // 레디스 좌석 정보 제거
+            redisSeatService.deleteSeatStock(reservation.getScheduleId());
+            
             // 예약 취소 처리
-            redisReservationCancelExecutor.execute(reservation);
+            redisReservationCancelExecutor.executeForPerformanceCancel(reservation);
         }
     }
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
@@ -42,7 +42,7 @@ public class RedisReservationBulkCancelService {
 
         for (Reservation reservation : reservations) {
             // 이미 취소된 예약은 패스
-            if (reservation.isAlreadyCanceled()) return;
+            if (reservation.isAlreadyCanceled()) continue;
 
             // 예약 취소 처리
             redisReservationCancelExecutor.execute(reservation);

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelService.java
@@ -62,4 +62,32 @@ public class RedisReservationBulkCancelService {
             redisReservationCancelExecutor.executeForPerformanceCancel(reservation);
         }
     }
+
+    /**
+     * 공연 회차 id를 기반으로 해당 회차에 대한 예약들을 일괄 취소
+     * TODO 공연 취소 이벤트 처리와 마찬가지로 벌크 처리 아직 구현 x
+     *
+     * @param scheduleId 취소된 공연 id
+     */
+    @Transactional
+    public void cancelAllByScheduleId(Long scheduleId) {
+        log.info("[회차 일괄 취소] 회차 id: {}", scheduleId);
+
+        // 회차 예약 목록 조회
+        List<Reservation> reservations = reservationRepository.findAllByScheduleId(scheduleId);
+
+        // 예약이 없으면 패스
+        if (reservations.isEmpty()) return;
+
+        // 레디스 좌석 정보 제거
+        redisSeatService.deleteSeatStock(scheduleId);
+
+        for (Reservation reservation : reservations) {
+            // 이미 취소된 예약은 패스
+            if (reservation.isAlreadyCanceled()) continue;
+
+            // 예약 취소 처리
+            redisReservationCancelExecutor.executeForPerformanceCancel(reservation);
+        }
+    }
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationCancelExecutor.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationCancelExecutor.java
@@ -1,0 +1,40 @@
+package me.performancereservation.domain.reservation.service.redis;
+
+import lombok.RequiredArgsConstructor;
+import me.performancereservation.domain.refund.RefundService;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.global.storage.redis.RedisReservationService;
+import me.performancereservation.global.storage.redis.RedisSeatService;
+import org.springframework.stereotype.Component;
+
+/**
+ * 예약 취소 로직 실행기
+ */
+@Component
+@RequiredArgsConstructor
+public class RedisReservationCancelExecutor {
+
+    private final RefundService refundService;
+    private final RedisSeatService redisSeatService;
+    private final RedisReservationService redisReservationService;
+
+    // 예약 취소 로직 실행 (단일 예약 취소)
+    public void execute(Reservation reservation) {
+        // 결제 완료된 예약인 경우 환불 요청 상태로 변경
+        if (reservation.isRefundRequired()) {
+            reservation.requestCancel(); // CANCEL_PENDING
+
+            // 환불 객체 생성
+            refundService.save(reservation);
+        } else {
+            // 결제 미완료 상태라면 바로 취소 확정 처리
+            reservation.cancelConfirm(); // CANCEL_CONFIRMED
+        }
+
+        // Redis 좌석 롤백 처리
+        redisSeatService.safeIncrement(reservation.getScheduleId(), reservation.getQuantity());
+
+        // 예약 만료 처리 대기 큐에서도 제거
+        redisReservationService.removeFromPendingExpirationQueue(reservation.getId());
+    }
+}

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationCancelExecutor.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationCancelExecutor.java
@@ -18,8 +18,18 @@ public class RedisReservationCancelExecutor {
     private final RedisSeatService redisSeatService;
     private final RedisReservationService redisReservationService;
 
-    // 예약 취소 로직 실행 (단일 예약 취소)
-    public void execute(Reservation reservation) {
+    // 유저가 취소했을 경우 (레디스 좌석 롤백 필요)
+    public void executeForUserCancel(Reservation reservation) {
+        execute(reservation, true);
+    }
+
+    // 공연이 취소됐을 경우 (레디스 좌석 롤백 불필요)
+    public void executeForPerformanceCancel(Reservation reservation) {
+        execute(reservation, false);
+    }
+
+    // 예약 취소 로직 실행 (단일 예약 취소 + 환불 객체 생성)
+    private void execute(Reservation reservation, boolean rollbackSeat) {
         // 결제 완료된 예약인 경우 환불 요청 상태로 변경
         if (reservation.isRefundRequired()) {
             reservation.requestCancel(); // CANCEL_PENDING
@@ -31,8 +41,11 @@ public class RedisReservationCancelExecutor {
             reservation.cancelConfirm(); // CANCEL_CONFIRMED
         }
 
-        // Redis 좌석 롤백 처리
-        redisSeatService.safeIncrement(reservation.getScheduleId(), reservation.getQuantity());
+        // 레디스 좌석 롤백이 필요한가?
+        if (rollbackSeat) {
+            // Redis 좌석 롤백 처리
+            redisSeatService.safeIncrement(reservation.getScheduleId(), reservation.getQuantity());
+        }
 
         // 예약 만료 처리 대기 큐에서도 제거
         redisReservationService.removeFromPendingExpirationQueue(reservation.getId());

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationService.java
@@ -104,6 +104,6 @@ public class RedisSeatReservationService implements SeatReservationService {
         }
 
         // 예약 취소 처리
-        redisReservationCancelExecutor.execute(reservation);
+        redisReservationCancelExecutor.executeForUserCancel(reservation);
     }
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationService.java
@@ -2,6 +2,7 @@ package me.performancereservation.domain.reservation.service.redis;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.performancereservation.domain.performance.model.SchedulePerformanceInfo;
 import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
 import me.performancereservation.domain.reservation.Reservation;
@@ -15,6 +16,10 @@ import me.performancereservation.global.storage.redis.RedisReservationService;
 import me.performancereservation.global.storage.redis.RedisSeatService;
 import org.springframework.stereotype.Service;
 
+/**
+ * 유저 단위의 예약, 예약 취소 서비스
+ */
+@Slf4j
 @Service("redisSeatReservationService")
 @RequiredArgsConstructor
 public class RedisSeatReservationService implements SeatReservationService {
@@ -25,6 +30,9 @@ public class RedisSeatReservationService implements SeatReservationService {
     private final RedisReservationService redisReservationService;
 
     private final ReservationMapper reservationMapper;
+
+    private final RedisReservationCancelExecutor redisReservationCancelExecutor;
+
 
     /**
      * 공연 회차에 대해 좌석 선점 후 예약 정보를 생성하고 나서
@@ -95,23 +103,7 @@ public class RedisSeatReservationService implements SeatReservationService {
             throw ErrorCode.PERMISSION_DENIED.domainException("본인의 예약만 취소할 수 있습니다.");
         }
 
-        // 결제 완료 상태라면 환불 요청 상태로 전환
-        if (reservation.isRefundRequired()) {
-            reservation.requestCancel(); // CANCEL_PENDING
-
-            //TODO 환불서비스에 환불객체 생성 요청
-            // refundService.save(reservation);
-        } else {
-            // 결제 미완료 상태라면 바로 취소 확정 처리
-            reservation.cancelConfirm(); // CANCEL_CONFIRMED
-        }
-
-        // Redis 좌석 롤백 처리
-        redisSeatService.safeIncrement(reservation.getScheduleId(), reservation.getQuantity());
-
-        // 예약 만료 처리 대기 큐에서도 제거
-        redisReservationService.removeFromPendingExpirationQueue(reservation.getId());
+        // 예약 취소 처리
+        redisReservationCancelExecutor.execute(reservation);
     }
-
-    //TODO 이벤트리스너로 공연이 취소됐을 때 일괄 예약 취소
 }

--- a/backend/src/main/java/me/performancereservation/global/config/AsyncConfig.java
+++ b/backend/src/main/java/me/performancereservation/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package me.performancereservation.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend/src/main/java/me/performancereservation/global/storage/redis/RedisSeatService.java
+++ b/backend/src/main/java/me/performancereservation/global/storage/redis/RedisSeatService.java
@@ -35,6 +35,16 @@ public class RedisSeatService {
     }
 
     /**
+     * 공연 회차별 좌석 수를 Redis에서 제거
+     * 공연이 취소되거나 끝나면 제거해줘야 함
+     *
+     * @param scheduleId 공연 회차 ID
+     */
+    public void deleteSeatStock(Long scheduleId) {
+        redisTemplate.delete(key(scheduleId));
+    }
+
+    /**
      * Redis에 저장된 공연 회차의 좌석 수를 차감
      * 예약 시 좌석 선점 단계에서 사용되고 동시성 제어를 위해 원자적 연산으로 처리됨
      *

--- a/backend/src/test/java/me/performancereservation/domain/refund/RefundServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/refund/RefundServiceTest.java
@@ -68,7 +68,7 @@ class RefundServiceTest {
                 .price(10000)
                 .category(PerformanceCategory.OPERA)
                 .description("테스트 공연 설명")
-                .performance_date(LocalDateTime.now())
+                .performanceDate(LocalDateTime.now())
                 .status(PerformanceStatus.CONFIRMED)
                 .build();
         performance = performanceRepository.save(performance);
@@ -80,7 +80,7 @@ class RefundServiceTest {
                 .startTime(LocalDateTime.now().plusDays(7))
                 .endTime(LocalDateTime.now().plusDays(7).plusHours(2))
                 .remainingSeats(100)
-                .is_canceled(false)
+                .canceled(false)
                 .build();
         schedule = performanceScheduleRepository.save(schedule);
         log.info("PerformanceSchedule 저장 완료: id={}", schedule.getId());

--- a/backend/src/test/java/me/performancereservation/domain/reservation/service/ReservationQueryServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/reservation/service/ReservationQueryServiceTest.java
@@ -4,7 +4,7 @@ import me.performancereservation.domain.performance.model.SchedulePerformanceInf
 import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
 import me.performancereservation.domain.reservation.Reservation;
 import me.performancereservation.domain.reservation.ReservationRepository;
-import me.performancereservation.domain.reservation.dto.ReservationListResponse;
+import me.performancereservation.domain.reservation.dto.ReservationPageResponse;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
 import me.performancereservation.domain.reservation.mapper.ReservationMapper;
@@ -27,7 +27,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -71,7 +70,7 @@ class ReservationQueryServiceTest {
             LocalDateTime.now().plusHours(2)
         );
         
-        ReservationListResponse expectedResponse = new ReservationListResponse(
+        ReservationPageResponse expectedResponse = new ReservationPageResponse(
             1L,
             quantity,
             ReservationStatus.PAYMENTS_PENDING,
@@ -90,7 +89,7 @@ class ReservationQueryServiceTest {
         when(reservationMapper.toListResponseDto(any(Reservation.class), any(SchedulePerformanceInfo.class)))
             .thenReturn(expectedResponse);
         
-        Page<ReservationListResponse> result = queryService.getAllByUserId(userId, pageable);
+        Page<ReservationPageResponse> result = queryService.getAllByUserId(userId, pageable);
         
         // then
         assertNotNull(result);

--- a/backend/src/test/java/me/performancereservation/domain/reservation/service/ReservationQueryServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/reservation/service/ReservationQueryServiceTest.java
@@ -1,0 +1,209 @@
+package me.performancereservation.domain.reservation.service;
+
+import me.performancereservation.domain.performance.model.SchedulePerformanceInfo;
+import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.ReservationRepository;
+import me.performancereservation.domain.reservation.dto.ReservationListResponse;
+import me.performancereservation.domain.reservation.dto.ReservationResponse;
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import me.performancereservation.domain.reservation.mapper.ReservationMapper;
+import me.performancereservation.global.exception.AppException;
+import me.performancereservation.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationQueryServiceTest {
+    @Mock
+    private ReservationRepository reservationRepository;
+    
+    @Mock
+    private PerformanceScheduleRepository performanceScheduleRepository;
+    
+    @Mock
+    private ReservationMapper reservationMapper;
+    
+    @InjectMocks
+    private ReservationQueryService queryService;
+    
+    @Test
+    @DisplayName("사용자의 모든 예약 목록 조회")
+    void getAllByUserId_Success() {
+        // given
+        Long userId = 1L;
+        Long scheduleId = 1L;
+        int quantity = 2;
+        Pageable pageable = PageRequest.of(0, 10);
+        
+        Reservation reservation = Reservation.builder()
+            .id(1L)
+            .userId(userId)
+            .scheduleId(scheduleId)
+            .quantity(quantity)
+            .status(ReservationStatus.PAYMENTS_PENDING)
+            .build();
+        
+        SchedulePerformanceInfo scheduleInfo = new SchedulePerformanceInfo(
+            1L,
+            "Test Performance",
+            "Test Venue",
+            10000,
+            scheduleId,
+            LocalDateTime.now(),
+            LocalDateTime.now().plusHours(2)
+        );
+        
+        ReservationListResponse expectedResponse = new ReservationListResponse(
+            1L,
+            quantity,
+            ReservationStatus.PAYMENTS_PENDING,
+            LocalDateTime.now(),
+            "Test Performance",
+            "Test Venue",
+            10000,
+            20000
+        );
+        
+        // when
+        when(reservationRepository.findAllByUserId(userId, pageable))
+            .thenReturn(new PageImpl<>(List.of(reservation)));
+        when(performanceScheduleRepository.findAllSchedulePerformanceInfoByScheduleIds(List.of(scheduleId)))
+            .thenReturn(List.of(scheduleInfo));
+        when(reservationMapper.toListResponseDto(any(Reservation.class), any(SchedulePerformanceInfo.class)))
+            .thenReturn(expectedResponse);
+        
+        Page<ReservationListResponse> result = queryService.getAllByUserId(userId, pageable);
+        
+        // then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals(expectedResponse, result.getContent().get(0));
+        verify(reservationRepository).findAllByUserId(userId, pageable);
+        verify(performanceScheduleRepository).findAllSchedulePerformanceInfoByScheduleIds(List.of(scheduleId));
+    }
+    
+    @Test
+    @DisplayName("존재하지 않는 예약 상세 조회")
+    void getByReservationId_NotFound() {
+        // given
+        Long reservationId = 1L;
+        Long userId = 1L;
+        
+        // when
+        when(reservationRepository.findById(reservationId))
+            .thenReturn(Optional.empty());
+        
+        // then
+        AppException exception = assertThrows(AppException.class, () -> 
+            queryService.getByReservationId(reservationId, userId)
+        );
+        
+        assertEquals(ErrorCode.RESERVATION_NOT_FOUND, exception.getErrorCode());
+        verify(reservationRepository).findById(reservationId);
+        verify(performanceScheduleRepository, never()).findSchedulePerformanceInfoByScheduleId(anyLong());
+    }
+    
+    @Test
+    @DisplayName("다른 사용자의 예약 상세 조회")
+    void getByReservationId_Unauthorized() {
+        // given
+        Long reservationId = 1L;
+        Long userId = 1L;
+        Long otherUserId = 2L;
+        
+        Reservation reservation = Reservation.builder()
+            .id(reservationId)
+            .userId(otherUserId)
+            .scheduleId(1L)
+            .quantity(2)
+            .status(ReservationStatus.PAYMENTS_PENDING)
+            .build();
+        
+        // when
+        when(reservationRepository.findById(reservationId))
+            .thenReturn(Optional.of(reservation));
+        
+        // then
+        AppException exception = assertThrows(AppException.class, () -> 
+            queryService.getByReservationId(reservationId, userId)
+        );
+        
+        assertEquals(ErrorCode.PERMISSION_DENIED, exception.getErrorCode());
+        verify(reservationRepository).findById(reservationId);
+        verify(performanceScheduleRepository, never()).findSchedulePerformanceInfoByScheduleId(anyLong());
+    }
+    
+    @Test
+    @DisplayName("정상적인 예약 상세 조회")
+    void getByReservationId_Success() {
+        // given
+        Long reservationId = 1L;
+        Long userId = 1L;
+        Long scheduleId = 1L;
+        int quantity = 2;
+        
+        Reservation reservation = Reservation.builder()
+            .id(reservationId)
+            .userId(userId)
+            .scheduleId(scheduleId)
+            .quantity(quantity)
+            .status(ReservationStatus.PAYMENTS_PENDING)
+            .build();
+        
+        SchedulePerformanceInfo scheduleInfo = new SchedulePerformanceInfo(
+            1L,
+            "Test Performance",
+            "Test Venue",
+            10000,
+            scheduleId,
+            LocalDateTime.now(),
+            LocalDateTime.now().plusHours(2)
+        );
+        
+        ReservationResponse expectedResponse = new ReservationResponse(
+            reservationId,
+            "Test Performance",
+            "Test Venue",
+            quantity,
+            ReservationStatus.PAYMENTS_PENDING,
+            LocalDateTime.now(),
+            LocalDateTime.now().plusMinutes(30),
+            10000,
+            20000
+        );
+        
+        // when
+        when(reservationRepository.findById(reservationId))
+            .thenReturn(Optional.of(reservation));
+        when(performanceScheduleRepository.findSchedulePerformanceInfoByScheduleId(scheduleId))
+            .thenReturn(Optional.of(scheduleInfo));
+        when(reservationMapper.toResponseDto(any(Reservation.class), any(SchedulePerformanceInfo.class)))
+            .thenReturn(expectedResponse);
+        
+        ReservationResponse result = queryService.getByReservationId(reservationId, userId);
+        
+        // then
+        assertNotNull(result);
+        assertEquals(expectedResponse, result);
+        verify(reservationRepository).findById(reservationId);
+        verify(performanceScheduleRepository).findSchedulePerformanceInfoByScheduleId(scheduleId);
+    }
+} 

--- a/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelServiceTest.java
@@ -294,4 +294,98 @@ class RedisReservationBulkCancelServiceTest {
         verify(redisReservationCancelExecutor).executeForPerformanceCancel(confirmedReservation);
         verify(redisReservationCancelExecutor, never()).executeForPerformanceCancel(canceledReservation);
     }
+
+    @Test
+    @DisplayName("특정 일정의 모든 예약 일괄 취소 성공")
+    void cancelAllByScheduleId_Success() {
+        // given
+        Long scheduleId = 1L;
+        
+        // 취소할 예약들
+        Reservation pendingReservation = Reservation.builder()
+            .id(1L)
+            .scheduleId(scheduleId)
+            .userId(1L)
+            .quantity(2)
+            .status(ReservationStatus.PAYMENTS_PENDING)
+            .build();
+            
+        Reservation confirmedReservation = Reservation.builder()
+            .id(2L)
+            .scheduleId(scheduleId)
+            .userId(2L)
+            .quantity(1)
+            .status(ReservationStatus.PAYMENTS_CONFIRMED)
+            .build();
+
+        List<Reservation> reservations = Arrays.asList(pendingReservation, confirmedReservation);
+
+        // when
+        when(reservationRepository.findAllByScheduleId(scheduleId))
+            .thenReturn(reservations);
+
+        bulkCancelService.cancelAllByScheduleId(scheduleId);
+
+        // then
+        verify(reservationRepository).findAllByScheduleId(scheduleId);
+        verify(redisSeatService).deleteSeatStock(scheduleId);
+        verify(redisReservationCancelExecutor, times(2)).executeForPerformanceCancel(any(Reservation.class));
+        verify(redisReservationCancelExecutor).executeForPerformanceCancel(pendingReservation);
+        verify(redisReservationCancelExecutor).executeForPerformanceCancel(confirmedReservation);
+    }
+
+    @Test
+    @DisplayName("특정 일정에 취소할 예약이 없는 경우")
+    void cancelAllByScheduleId_NoReservations() {
+        // given
+        Long scheduleId = 1L;
+
+        // when
+        when(reservationRepository.findAllByScheduleId(scheduleId))
+            .thenReturn(Collections.emptyList());
+
+        bulkCancelService.cancelAllByScheduleId(scheduleId);
+
+        // then
+        verify(reservationRepository).findAllByScheduleId(scheduleId);
+        verify(redisSeatService, never()).deleteSeatStock(anyLong());
+        verify(redisReservationCancelExecutor, never()).executeForPerformanceCancel(any(Reservation.class));
+    }
+
+    @Test
+    @DisplayName("특정 일정에 이미 취소된 예약만 있는 경우")
+    void cancelAllByScheduleId_AlreadyCanceled() {
+        // given
+        Long scheduleId = 1L;
+        
+        // 이미 취소된 예약들
+        Reservation canceledReservation1 = Reservation.builder()
+            .id(1L)
+            .scheduleId(scheduleId)
+            .userId(1L)
+            .quantity(2)
+            .status(ReservationStatus.CANCEL_CONFIRMED)
+            .build();
+
+        Reservation canceledReservation2 = Reservation.builder()
+            .id(2L)
+            .scheduleId(scheduleId)
+            .userId(2L)
+            .quantity(1)
+            .status(ReservationStatus.CANCEL_PENDING)
+            .build();
+
+        List<Reservation> reservations = Arrays.asList(canceledReservation1, canceledReservation2);
+
+        // when
+        when(reservationRepository.findAllByScheduleId(scheduleId))
+            .thenReturn(reservations);
+
+        bulkCancelService.cancelAllByScheduleId(scheduleId);
+
+        // then
+        verify(reservationRepository).findAllByScheduleId(scheduleId);
+        verify(redisSeatService).deleteSeatStock(scheduleId);
+        verify(redisReservationCancelExecutor, never()).executeForPerformanceCancel(any(Reservation.class));
+    }
 } 

--- a/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelServiceTest.java
@@ -1,0 +1,119 @@
+package me.performancereservation.domain.reservation.service.redis;
+
+import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
+import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.reservation.ReservationRepository;
+import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RedisReservationBulkCancelServiceTest {
+
+    @Mock
+    private PerformanceScheduleRepository performanceScheduleRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private RedisReservationCancelExecutor redisReservationCancelExecutor;
+
+    @InjectMocks
+    private RedisReservationBulkCancelService bulkCancelService;
+
+    @Test
+    @DisplayName("정상적인 일괄 취소")
+    void cancelAllByPerformanceId_Success() {
+        // given
+        Long performanceId = 1L;
+        List<Long> scheduleIds = Arrays.asList(1L, 2L);
+        
+        Reservation reservation1 = Reservation.builder()
+            .id(1L)
+            .scheduleId(1L)
+            .userId(1L)
+            .quantity(2)
+            .status(ReservationStatus.PAYMENTS_PENDING)
+            .build();
+            
+        Reservation reservation2 = Reservation.builder()
+            .id(2L)
+            .scheduleId(2L)
+            .userId(2L)
+            .quantity(1)
+            .status(ReservationStatus.PAYMENTS_CONFIRMED)
+            .build();
+
+        List<Reservation> reservations = Arrays.asList(reservation1, reservation2);
+
+        // when
+        when(performanceScheduleRepository.findIdsByPerformanceId(performanceId))
+            .thenReturn(scheduleIds);
+        when(reservationRepository.findAllByScheduleIds(scheduleIds))
+            .thenReturn(reservations);
+
+        bulkCancelService.cancelAllByPerformanceId(performanceId);
+
+        // then
+        verify(redisReservationCancelExecutor, times(2)).execute(any(Reservation.class));
+    }
+
+    @Test
+    @DisplayName("취소할 예약이 없는 경우")
+    void cancelAllByPerformanceId_NoReservations() {
+        // given
+        Long performanceId = 1L;
+        List<Long> scheduleIds = Arrays.asList(1L, 2L);
+
+        // when
+        when(performanceScheduleRepository.findIdsByPerformanceId(performanceId))
+            .thenReturn(scheduleIds);
+        when(reservationRepository.findAllByScheduleIds(scheduleIds))
+            .thenReturn(List.of());
+
+        bulkCancelService.cancelAllByPerformanceId(performanceId);
+
+        // then
+        verify(redisReservationCancelExecutor, never()).execute(any(Reservation.class));
+    }
+
+    @Test
+    @DisplayName("이미 취소된 예약이 있는 경우")
+    void cancelAllByPerformanceId_AlreadyCanceled() {
+        // given
+        Long performanceId = 1L;
+        List<Long> scheduleIds = Arrays.asList(1L);
+        
+        Reservation canceledReservation = Reservation.builder()
+            .id(1L)
+            .scheduleId(1L)
+            .userId(1L)
+            .quantity(2)
+            .status(ReservationStatus.CANCEL_CONFIRMED)
+            .build();
+
+        List<Reservation> reservations = List.of(canceledReservation);
+
+        // when
+        when(performanceScheduleRepository.findIdsByPerformanceId(performanceId))
+            .thenReturn(scheduleIds);
+        when(reservationRepository.findAllByScheduleIds(scheduleIds))
+            .thenReturn(reservations);
+
+        bulkCancelService.cancelAllByPerformanceId(performanceId);
+
+        // then
+        verify(redisReservationCancelExecutor, never()).execute(any(Reservation.class));
+    }
+} 

--- a/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisReservationBulkCancelServiceTest.java
@@ -1,9 +1,14 @@
 package me.performancereservation.domain.reservation.service.redis;
 
+import me.performancereservation.domain.performance.entities.Performance;
+import me.performancereservation.domain.performance.entities.PerformanceSchedule;
+import me.performancereservation.domain.performance.enums.PerformanceCategory;
+import me.performancereservation.domain.performance.enums.PerformanceStatus;
 import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
 import me.performancereservation.domain.reservation.Reservation;
 import me.performancereservation.domain.reservation.ReservationRepository;
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import me.performancereservation.global.storage.redis.RedisSeatService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,10 +16,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,16 +37,49 @@ class RedisReservationBulkCancelServiceTest {
     @Mock
     private RedisReservationCancelExecutor redisReservationCancelExecutor;
 
+    @Mock
+    private RedisSeatService redisSeatService;
+
     @InjectMocks
     private RedisReservationBulkCancelService bulkCancelService;
 
     @Test
-    @DisplayName("정상적인 일괄 취소")
+    @DisplayName("공연의 모든 예약 일괄 취소 성공")
     void cancelAllByPerformanceId_Success() {
         // given
         Long performanceId = 1L;
         List<Long> scheduleIds = Arrays.asList(1L, 2L);
         
+        Performance performance = Performance.builder()
+            .id(performanceId)
+            .title("오페라 갈라")
+            .venue("세종문화회관 대극장")
+            .price(120000)
+            .totalSeats(2000)
+            .category(PerformanceCategory.OPERA)
+            .performanceDate(LocalDateTime.of(2025, 12, 13, 0, 0))
+            .description("한자리에서 만나는 오페라 명곡들 그리고 오페라 스타들!")
+            .status(PerformanceStatus.CONFIRMED)
+            .build();
+            
+        PerformanceSchedule schedule1 = PerformanceSchedule.builder()
+            .id(1L)
+            .performanceId(performanceId)
+            .startTime(LocalDateTime.of(2025, 12, 13, 9, 0))
+            .endTime(LocalDateTime.of(2025, 12, 13, 10, 0))
+            .remainingSeats(100)
+            .canceled(false)
+            .build();
+            
+        PerformanceSchedule schedule2 = PerformanceSchedule.builder()
+            .id(2L)
+            .performanceId(performanceId)
+            .startTime(LocalDateTime.of(2025, 12, 13, 11, 0))
+            .endTime(LocalDateTime.of(2025, 12, 13, 12, 0))
+            .remainingSeats(100)
+            .canceled(false)
+            .build();
+            
         Reservation reservation1 = Reservation.builder()
             .id(1L)
             .scheduleId(1L)
@@ -66,7 +107,10 @@ class RedisReservationBulkCancelServiceTest {
         bulkCancelService.cancelAllByPerformanceId(performanceId);
 
         // then
-        verify(redisReservationCancelExecutor, times(2)).execute(any(Reservation.class));
+        verify(redisSeatService, times(2)).deleteSeatStock(anyLong());
+        verify(redisReservationCancelExecutor, times(2)).executeForPerformanceCancel(any(Reservation.class));
+        verify(redisReservationCancelExecutor).executeForPerformanceCancel(reservation1);
+        verify(redisReservationCancelExecutor).executeForPerformanceCancel(reservation2);
     }
 
     @Test
@@ -75,27 +119,60 @@ class RedisReservationBulkCancelServiceTest {
         // given
         Long performanceId = 1L;
         List<Long> scheduleIds = Arrays.asList(1L, 2L);
+        
+        // 일정은 있지만 예약이 없는 경우
+        PerformanceSchedule schedule1 = PerformanceSchedule.builder()
+            .id(1L)
+            .performanceId(performanceId)
+            .startTime(LocalDateTime.of(2025, 12, 13, 9, 0))
+            .endTime(LocalDateTime.of(2025, 12, 13, 10, 0))
+            .remainingSeats(100)
+            .canceled(false)
+            .build();
+            
+        PerformanceSchedule schedule2 = PerformanceSchedule.builder()
+            .id(2L)
+            .performanceId(performanceId)
+            .startTime(LocalDateTime.of(2025, 12, 13, 11, 0))
+            .endTime(LocalDateTime.of(2025, 12, 13, 12, 0))
+            .remainingSeats(100)
+            .canceled(false)
+            .build();
 
         // when
         when(performanceScheduleRepository.findIdsByPerformanceId(performanceId))
             .thenReturn(scheduleIds);
         when(reservationRepository.findAllByScheduleIds(scheduleIds))
-            .thenReturn(List.of());
+            .thenReturn(Collections.emptyList());
 
         bulkCancelService.cancelAllByPerformanceId(performanceId);
 
         // then
-        verify(redisReservationCancelExecutor, never()).execute(any(Reservation.class));
+        verify(performanceScheduleRepository).findIdsByPerformanceId(performanceId);
+        verify(reservationRepository).findAllByScheduleIds(scheduleIds);
+        verify(redisSeatService, never()).deleteSeatStock(anyLong());
+        verify(redisReservationCancelExecutor, never()).executeForPerformanceCancel(any(Reservation.class));
     }
 
     @Test
-    @DisplayName("이미 취소된 예약이 있는 경우")
+    @DisplayName("이미 취소된 예약만 있는 경우")
     void cancelAllByPerformanceId_AlreadyCanceled() {
         // given
         Long performanceId = 1L;
         List<Long> scheduleIds = Arrays.asList(1L);
         
-        Reservation canceledReservation = Reservation.builder()
+        // 일정 정보
+        PerformanceSchedule schedule = PerformanceSchedule.builder()
+            .id(1L)
+            .performanceId(performanceId)
+            .startTime(LocalDateTime.of(2025, 12, 13, 9, 0))
+            .endTime(LocalDateTime.of(2025, 12, 13, 10, 0))
+            .remainingSeats(100)
+            .canceled(false)
+            .build();
+        
+        // 이미 취소된 예약들
+        Reservation canceledReservation1 = Reservation.builder()
             .id(1L)
             .scheduleId(1L)
             .userId(1L)
@@ -103,7 +180,15 @@ class RedisReservationBulkCancelServiceTest {
             .status(ReservationStatus.CANCEL_CONFIRMED)
             .build();
 
-        List<Reservation> reservations = List.of(canceledReservation);
+        Reservation canceledReservation2 = Reservation.builder()
+            .id(2L)
+            .scheduleId(1L)
+            .userId(2L)
+            .quantity(1)
+            .status(ReservationStatus.CANCEL_PENDING)
+            .build();
+
+        List<Reservation> reservations = Arrays.asList(canceledReservation1, canceledReservation2);
 
         // when
         when(performanceScheduleRepository.findIdsByPerformanceId(performanceId))
@@ -114,6 +199,99 @@ class RedisReservationBulkCancelServiceTest {
         bulkCancelService.cancelAllByPerformanceId(performanceId);
 
         // then
-        verify(redisReservationCancelExecutor, never()).execute(any(Reservation.class));
+        verify(performanceScheduleRepository).findIdsByPerformanceId(performanceId);
+        verify(reservationRepository).findAllByScheduleIds(scheduleIds);
+        verify(redisSeatService, never()).deleteSeatStock(anyLong());
+        verify(redisReservationCancelExecutor, never()).executeForPerformanceCancel(any(Reservation.class));
+    }
+    
+    @Test
+    @DisplayName("공연에 대한 일정이 없는 경우 취소 처리")
+    void cancelAllByPerformanceId_NoSchedules() {
+        // given
+        Long performanceId = 1L;
+        List<Long> emptyScheduleIds = Collections.emptyList();
+        when(performanceScheduleRepository.findIdsByPerformanceId(performanceId))
+            .thenReturn(emptyScheduleIds);
+
+        // when
+        bulkCancelService.cancelAllByPerformanceId(performanceId);
+
+        // then
+        verify(performanceScheduleRepository).findIdsByPerformanceId(performanceId);
+        verify(redisSeatService, never()).deleteSeatStock(anyLong());
+        verify(reservationRepository, never()).findAllByScheduleIds(anyList());
+        verify(redisReservationCancelExecutor, never()).executeForPerformanceCancel(any(Reservation.class));
+    }
+    
+    @Test
+    @DisplayName("다양한 상태의 예약이 있는 경우")
+    void cancelAllByPerformanceId_MixedStatus() {
+        // given
+        Long performanceId = 1L;
+        List<Long> scheduleIds = Arrays.asList(1L, 2L);
+        
+        PerformanceSchedule schedule1 = PerformanceSchedule.builder()
+            .id(1L)
+            .performanceId(performanceId)
+            .startTime(LocalDateTime.of(2025, 12, 13, 9, 0))
+            .endTime(LocalDateTime.of(2025, 12, 13, 10, 0))
+            .remainingSeats(100)
+            .canceled(false)
+            .build();
+            
+        PerformanceSchedule schedule2 = PerformanceSchedule.builder()
+            .id(2L)
+            .performanceId(performanceId)
+            .startTime(LocalDateTime.of(2025, 12, 13, 11, 0))
+            .endTime(LocalDateTime.of(2025, 12, 13, 12, 0))
+            .remainingSeats(100)
+            .canceled(false)
+            .build();
+            
+        Reservation pendingReservation = Reservation.builder()
+            .id(1L)
+            .scheduleId(1L)
+            .userId(1L)
+            .quantity(2)
+            .status(ReservationStatus.PAYMENTS_PENDING)
+            .build();
+            
+        Reservation confirmedReservation = Reservation.builder()
+            .id(2L)
+            .scheduleId(2L)
+            .userId(2L)
+            .quantity(1)
+            .status(ReservationStatus.PAYMENTS_CONFIRMED)
+            .build();
+            
+        Reservation canceledReservation = Reservation.builder()
+            .id(3L)
+            .scheduleId(1L)
+            .userId(3L)
+            .quantity(3)
+            .status(ReservationStatus.CANCEL_CONFIRMED)
+            .build();
+
+        List<Reservation> reservations = Arrays.asList(
+            pendingReservation,
+            confirmedReservation,
+            canceledReservation
+        );
+
+        // when
+        when(performanceScheduleRepository.findIdsByPerformanceId(performanceId))
+            .thenReturn(scheduleIds);
+        when(reservationRepository.findAllByScheduleIds(scheduleIds))
+            .thenReturn(reservations);
+
+        bulkCancelService.cancelAllByPerformanceId(performanceId);
+
+        // then
+        verify(redisSeatService, times(2)).deleteSeatStock(anyLong());
+        verify(redisReservationCancelExecutor, times(2)).executeForPerformanceCancel(any(Reservation.class));
+        verify(redisReservationCancelExecutor).executeForPerformanceCancel(pendingReservation);
+        verify(redisReservationCancelExecutor).executeForPerformanceCancel(confirmedReservation);
+        verify(redisReservationCancelExecutor, never()).executeForPerformanceCancel(canceledReservation);
     }
 } 

--- a/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationServiceTest.java
@@ -42,6 +42,9 @@ class RedisSeatReservationServiceTest {
     
     @Mock
     private ReservationMapper reservationMapper;
+
+    @Mock
+    private RedisReservationCancelExecutor redisReservationCancelExecutor;
     
     @InjectMocks
     private RedisSeatReservationService reservationService;
@@ -169,9 +172,7 @@ class RedisSeatReservationServiceTest {
         reservationService.cancel(reservationId, userId);
         
         // then
-        assertEquals(ReservationStatus.CANCEL_CONFIRMED, reservation.getStatus());
-        verify(redisSeatService).safeIncrement(scheduleId, quantity);
-        verify(redisReservationService).removeFromPendingExpirationQueue(reservationId);
+        verify(redisReservationCancelExecutor).executeForUserCancel(reservation);
     }
     
     @Test
@@ -197,8 +198,7 @@ class RedisSeatReservationServiceTest {
         );
         
         assertEquals(ErrorCode.ALREADY_CANCELED_RESERVATION, exception.getErrorCode());
-        verify(redisSeatService, never()).safeIncrement(anyLong(), anyInt());
-        verify(redisReservationService, never()).removeFromPendingExpirationQueue(anyLong());
+        verify(redisReservationCancelExecutor, never()).executeForUserCancel(any(Reservation.class));
     }
     
     @Test
@@ -225,8 +225,7 @@ class RedisSeatReservationServiceTest {
         );
         
         assertEquals(ErrorCode.PERMISSION_DENIED, exception.getErrorCode());
-        verify(redisSeatService, never()).safeIncrement(anyLong(), anyInt());
-        verify(redisReservationService, never()).removeFromPendingExpirationQueue(anyLong());
+        verify(redisReservationCancelExecutor, never()).executeForUserCancel(any(Reservation.class));
     }
     
     @Test
@@ -246,8 +245,7 @@ class RedisSeatReservationServiceTest {
         );
         
         assertEquals(ErrorCode.RESERVATION_NOT_FOUND, exception.getErrorCode());
-        verify(redisSeatService, never()).safeIncrement(anyLong(), anyInt());
-        verify(redisReservationService, never()).removeFromPendingExpirationQueue(anyLong());
+        verify(redisReservationCancelExecutor, never()).executeForUserCancel(any(Reservation.class));
     }
     
     @Test
@@ -274,8 +272,6 @@ class RedisSeatReservationServiceTest {
         reservationService.cancel(reservationId, userId);
         
         // then
-        assertEquals(ReservationStatus.CANCEL_PENDING, reservation.getStatus());
-        verify(redisSeatService).safeIncrement(scheduleId, quantity);
-        verify(redisReservationService).removeFromPendingExpirationQueue(reservationId);
+        verify(redisReservationCancelExecutor).executeForUserCancel(reservation);
     }
 } 


### PR DESCRIPTION
## #️⃣ Issue Number

#26

## 📝 요약(Summary)
**/api**
- ReservationController

**/domain**
- /performance/repository/PerformanceScheduleRepository - SchedulePerformanceInfo 리스트 조회해야해서 수정
<br/>

- /reservation/ReservationRepository - 조회를 위해 findAllByUserId() 추가
- /reservation/dto/ReservationListResponse - 예약 목록 조회를 위한 Response dto
- /reservation/mapper/ReservationMapper - 예약 목록 조회를 위한 매퍼 추가
- /reservation/service/ReservationQueryService - 조회 api를 위한 서비스 추가

**test**
- ReservationQueryServiceTest - 예약 조회 테스트
- RefundServiceTest - performance_date를 performanceDate로 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가
-   [x] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [x] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
유저 본인의 예약 조회용입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
