### PR TITLE
fix(reservation, security): 패스워드인코더 및 예약검색 테스트 오류 해결

### DIFF
--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/ReservationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
@@ -18,4 +19,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         WHERE r.id IN :ids AND r.status = :status
     """)
     List<Reservation> findAllByIdsAndStatus(@Param("ids") List<Long> ids, @Param("status") ReservationStatus status);
+
+    Optional<Reservation> findByUserId(Long userId);
 }

--- a/backend/src/main/java/me/performancereservation/global/config/AdminInitializer.java
+++ b/backend/src/main/java/me/performancereservation/global/config/AdminInitializer.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.performancereservation.domain.admin.Admin;
 import me.performancereservation.domain.admin.repository.AdminRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +18,8 @@ import org.springframework.stereotype.Component;
 public class AdminInitializer {
 
     private final AdminRepository adminRepository;
+
+//    @Qualifier("adminPasswordEncoder")
     private final PasswordEncoder passwordEncoder;
 
     @Value("${app.admin.id}")

--- a/backend/src/main/java/me/performancereservation/global/config/AdminSecurityConfig.java
+++ b/backend/src/main/java/me/performancereservation/global/config/AdminSecurityConfig.java
@@ -28,6 +28,10 @@ public class AdminSecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;            // 로그인이 안된 경우를 처리하는 핸들러
     private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;    // 로그인 실패 핸들러
 
+//    @Bean("adminPasswordEncoder")
+//    public PasswordEncoder adminPasswordEncoder() {
+//        return new BCryptPasswordEncoder();
+//    }
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/backend/src/main/java/me/performancereservation/global/config/AdminSecurityConfig.java
+++ b/backend/src/main/java/me/performancereservation/global/config/AdminSecurityConfig.java
@@ -28,10 +28,6 @@ public class AdminSecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;            // 로그인이 안된 경우를 처리하는 핸들러
     private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;    // 로그인 실패 핸들러
 
-//    @Bean("adminPasswordEncoder")
-//    public PasswordEncoder adminPasswordEncoder() {
-//        return new BCryptPasswordEncoder();
-//    }
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/backend/src/main/java/me/performancereservation/global/config/SecurityConfig.java
+++ b/backend/src/main/java/me/performancereservation/global/config/SecurityConfig.java
@@ -30,10 +30,11 @@ public class SecurityConfig {
     private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
 
     //비밀번호 암호화용 PasswordEncoder 빈 등록 : 소셜로그인만 써도 확장성/관례상 등록해주기!!
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+//    @Bean("userPasswordEncoder")
+//    public PasswordEncoder userPasswordEncoder() {
+//        return new BCryptPasswordEncoder();
+//    }
+    private final PasswordEncoder passwordEncoder;
 
     //SecurityFilterChain : 인증/인가, OAuth2, JWT, CORS, CSRF 등 모든 정책을 한 곳에서 관리
     @Bean

--- a/backend/src/main/java/me/performancereservation/global/config/SecurityConfig.java
+++ b/backend/src/main/java/me/performancereservation/global/config/SecurityConfig.java
@@ -13,7 +13,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -29,11 +28,8 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
 
-    //비밀번호 암호화용 PasswordEncoder 빈 등록 : 소셜로그인만 써도 확장성/관례상 등록해주기!!
-//    @Bean("userPasswordEncoder")
-//    public PasswordEncoder userPasswordEncoder() {
-//        return new BCryptPasswordEncoder();
-//    }
+    // 비밀번호 암호화용 PasswordEncoder 빈 등록 : 소셜로그인만 써도 확장성/관례상 등록해주기!!
+    // AdminSecurityConfig에서 등록한 passwordEncoder bean을 주입받아 사용
     private final PasswordEncoder passwordEncoder;
 
     //SecurityFilterChain : 인증/인가, OAuth2, JWT, CORS, CSRF 등 모든 정책을 한 곳에서 관리

--- a/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
+++ b/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
@@ -212,7 +212,7 @@ class AdminReservationControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void getReservationListPaging_Success() throws Exception {
-        mockMvc.perform(get("/admin/reservations")
+        mockMvc.perform(get("/api/v1//admin/reservations")
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
@@ -226,7 +226,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByName_Success() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1//admin/reservations/search")
                         .param("userName", "사용자1")
                         .param("page", "0")
                         .param("size", "10"))
@@ -240,7 +240,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByName_Failure() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1//admin/reservations/search")
                         .param("userName", "없는 사용자")
                         .param("page", "0")
                         .param("size", "10"))
@@ -254,7 +254,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByTitle_Success() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1//admin/reservations/search")
                         .param("performanceTitle", "오페라 갈라")
                         .param("page", "0")
                         .param("size", "10"))
@@ -268,7 +268,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByTitle_Failure() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1//admin/reservations/search")
                         .param("performanceTitle", "없는 공연")
                         .param("page", "0")
                         .param("size", "10"))
@@ -282,7 +282,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByStatus_PAYMENT_PENDING() throws Exception {
         // PAYMENTS_PENDING: 50 / 2 = 25개
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1//admin/reservations/search")
                         .param("reservationStatus", "PAYMENTS_PENDING")
                         .param("page", "0")
                         .param("size", "10"))
@@ -296,7 +296,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByStatus_CANCELPENDING() throws Exception {
         // PAYMENTS_PENDING: 50 / 2 = 25개
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1//admin/reservations/search")
                         .param("reservationStatus", "CANCEL_PENDING")
                         .param("page", "0")
                         .param("size", "10"))
@@ -313,7 +313,7 @@ class AdminReservationControllerTest {
         LocalDateTime start = LocalDateTime.now().minusDays(1).toLocalDate().atStartOfDay();
         LocalDateTime end = LocalDateTime.now().plusDays(1).toLocalDate().atTime(23, 59, 59);
 
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("startDate", start.toString())
                         .param("endDate", end.toString())
                         .param("page", "0")
@@ -331,7 +331,7 @@ class AdminReservationControllerTest {
         LocalDateTime start = LocalDateTime.now().minusDays(11).toLocalDate().atStartOfDay();
         LocalDateTime end = LocalDateTime.now().minusDays(10).toLocalDate().atTime(23, 59, 59);
 
-        mockMvc.perform(get("/admin/reservations/search")
+        mockMvc.perform(get("/api/v1//admin/reservations/search")
                         .param("startDate", start.toString())
                         .param("endDate", end.toString())
                         .param("page", "0")
@@ -348,7 +348,7 @@ class AdminReservationControllerTest {
         // 펜딩 상태 예약 확정 성공
         Reservation pending = reservationRepository.findById(user5.getId()).get();
 
-        mockMvc.perform(patch("/admin/reservations/" + pending.getId())
+        mockMvc.perform(patch("/api/v1//admin/reservations/" + pending.getId())
                         .with(csrf()))
                 .andExpect(status().isNoContent());
 
@@ -368,7 +368,7 @@ class AdminReservationControllerTest {
         // 이미 확정된 예약에 대해 확정 요청 시 409 CONFLICT
         Reservation confirmed = reservationRepository.findById(user6.getId()).get();
 
-        mockMvc.perform(patch("/admin/reservations/" + confirmed.getId())
+        mockMvc.perform(patch("/api/v1//admin/reservations/" + confirmed.getId())
                         .with(csrf()))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").value("이미 확정된 예약입니다."));
@@ -381,7 +381,7 @@ class AdminReservationControllerTest {
         Reservation cancelPending = reservationRepository.findById(user7.getId()).get();
         cancelPending.requestCancel();
 
-        mockMvc.perform(patch("/admin/reservations/" + cancelPending.getId())
+        mockMvc.perform(patch("/api/v1//admin/reservations/" + cancelPending.getId())
                         .with(csrf()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("유효하지 않은 예약 상태입니다."));
@@ -389,7 +389,7 @@ class AdminReservationControllerTest {
         Reservation cancelConfirmed = reservationRepository.findById(user8.getId()).get();
         cancelConfirmed.cancelConfirm();
 
-        mockMvc.perform(patch("/admin/reservations/" + cancelConfirmed.getId())
+        mockMvc.perform(patch("/api/v1//admin/reservations/" + cancelConfirmed.getId())
                         .with(csrf()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("유효하지 않은 예약 상태입니다."));

--- a/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
+++ b/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
@@ -55,6 +55,7 @@ class AdminReservationControllerTest {
     User user6;
     User user7;
     User user8;
+    User user9;
 
     @BeforeEach
     void init() {
@@ -120,6 +121,15 @@ class AdminReservationControllerTest {
                         .name("사용자8")
                         .email("user8@gmail.com")
                         .phoneNumber("010-8888-8888")
+                        .build()
+        );
+
+        user9 = userRepository.save(
+                User.builder()
+                        .role(Role.USER)
+                        .name("사용자9")
+                        .email("user9@gmail.com")
+                        .phoneNumber("010-9999-9999")
                         .build()
         );
 
@@ -206,6 +216,15 @@ class AdminReservationControllerTest {
                         .status(ReservationStatus.PAYMENTS_PENDING)
                         .build()
         );
+
+        reservationRepository.save(
+                Reservation.builder()
+                        .userId(user9.getId())
+                        .quantity(1)
+                        .scheduleId(schedule.getId())
+                        .status(ReservationStatus.CANCEL_PENDING) //CANCEL_PENDING 검색 테스트용
+                        .build()
+        );
     }
 
 
@@ -218,7 +237,7 @@ class AdminReservationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10)) // 1페이지 10개
                 .andExpect(jsonPath("$.totalPages").value(6)) // 54 / 10 = 5.4 -> 6페이지
-                .andExpect(jsonPath("$.totalElements").value(54)); // 총 50개
+                .andExpect(jsonPath("$.totalElements").value(55)); // 총 50개
     }
 
 
@@ -260,7 +279,7 @@ class AdminReservationControllerTest {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10)) // 1페이지 10개
-                .andExpect(jsonPath("$.totalElements").value(54)) // 총 50개
+                .andExpect(jsonPath("$.totalElements").value(55)) // 총 50개
                 .andExpect(jsonPath("$.totalPages").value(6)); // 54 / 10 = 5.4 → 6페이지
     }
 
@@ -282,13 +301,13 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByStatus_PAYMENT_PENDING() throws Exception {
         // PAYMENTS_PENDING: 50 / 2 = 25개
-        mockMvc.perform(get("/api/v1//admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("reservationStatus", "PAYMENTS_PENDING")
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10))
-                .andExpect(jsonPath("$.totalElements").value(26)) // 25개
+                .andExpect(jsonPath("$.totalElements").value(28)) // 25개
                 .andExpect(jsonPath("$.totalPages").value(3)); // 26 / 10 = 2.6 → 3페이지
     }
 
@@ -296,7 +315,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByStatus_CANCELPENDING() throws Exception {
         // PAYMENTS_PENDING: 50 / 2 = 25개
-        mockMvc.perform(get("/api/v1//admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("reservationStatus", "CANCEL_PENDING")
                         .param("page", "0")
                         .param("size", "10"))
@@ -320,7 +339,7 @@ class AdminReservationControllerTest {
                         .param("size", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.size()").value(10))
-                .andExpect(jsonPath("$.totalElements").value(54)) // 전체 50개
+                .andExpect(jsonPath("$.totalElements").value(55)) // 전체 50개
                 .andExpect(jsonPath("$.totalPages").value(6));
     }
 
@@ -346,7 +365,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void confirmReservation_Success() throws Exception {
         // 펜딩 상태 예약 확정 성공
-        Reservation pending = reservationRepository.findById(user5.getId()).get();
+        Reservation pending = reservationRepository.findByUserId(user5.getId()).get();
 
         mockMvc.perform(patch("/api/v1//admin/reservations/" + pending.getId())
                         .with(csrf()))
@@ -366,9 +385,9 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void confirmReservationAlreadyConfirmed_Failure() throws Exception {
         // 이미 확정된 예약에 대해 확정 요청 시 409 CONFLICT
-        Reservation confirmed = reservationRepository.findById(user6.getId()).get();
+        Reservation confirmed = reservationRepository.findByUserId(user6.getId()).get();
 
-        mockMvc.perform(patch("/api/v1//admin/reservations/" + confirmed.getId())
+        mockMvc.perform(patch("/api/v1/admin/reservations/" + confirmed.getId())
                         .with(csrf()))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").value("이미 확정된 예약입니다."));
@@ -378,18 +397,18 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void confirmReservationCanceledStatus_Failure() throws Exception {
         // 취소 상태 예약에 대해 확정 요청 시 400 BAD_REQUEST
-        Reservation cancelPending = reservationRepository.findById(user7.getId()).get();
+        Reservation cancelPending = reservationRepository.findByUserId(user7.getId()).get();
         cancelPending.requestCancel();
 
-        mockMvc.perform(patch("/api/v1//admin/reservations/" + cancelPending.getId())
+        mockMvc.perform(patch("/api/v1/admin/reservations/" + cancelPending.getId())
                         .with(csrf()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("유효하지 않은 예약 상태입니다."));
 
-        Reservation cancelConfirmed = reservationRepository.findById(user8.getId()).get();
+        Reservation cancelConfirmed = reservationRepository.findByUserId(user8.getId()).get();
         cancelConfirmed.cancelConfirm();
 
-        mockMvc.perform(patch("/api/v1//admin/reservations/" + cancelConfirmed.getId())
+        mockMvc.perform(patch("/api/v1/admin/reservations/" + cancelConfirmed.getId())
                         .with(csrf()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("유효하지 않은 예약 상태입니다."));

--- a/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
+++ b/backend/src/test/java/me/performancereservation/api/AdminReservationControllerTest.java
@@ -231,7 +231,7 @@ class AdminReservationControllerTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void getReservationListPaging_Success() throws Exception {
-        mockMvc.perform(get("/api/v1//admin/reservations")
+        mockMvc.perform(get("/api/v1/admin/reservations")
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())
@@ -245,7 +245,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByName_Success() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/api/v1//admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("userName", "사용자1")
                         .param("page", "0")
                         .param("size", "10"))
@@ -259,7 +259,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByName_Failure() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/api/v1//admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("userName", "없는 사용자")
                         .param("page", "0")
                         .param("size", "10"))
@@ -273,7 +273,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByTitle_Success() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/api/v1//admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("performanceTitle", "오페라 갈라")
                         .param("page", "0")
                         .param("size", "10"))
@@ -287,7 +287,7 @@ class AdminReservationControllerTest {
     @WithMockUser(roles = "ADMIN")
     void searchReservationByTitle_Failure() throws Exception {
         // 사용자1의 예약 수 = 50 / 4 = 12.5 → 13개
-        mockMvc.perform(get("/api/v1//admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("performanceTitle", "없는 공연")
                         .param("page", "0")
                         .param("size", "10"))
@@ -350,7 +350,7 @@ class AdminReservationControllerTest {
         LocalDateTime start = LocalDateTime.now().minusDays(11).toLocalDate().atStartOfDay();
         LocalDateTime end = LocalDateTime.now().minusDays(10).toLocalDate().atTime(23, 59, 59);
 
-        mockMvc.perform(get("/api/v1//admin/reservations/search")
+        mockMvc.perform(get("/api/v1/admin/reservations/search")
                         .param("startDate", start.toString())
                         .param("endDate", end.toString())
                         .param("page", "0")
@@ -367,7 +367,7 @@ class AdminReservationControllerTest {
         // 펜딩 상태 예약 확정 성공
         Reservation pending = reservationRepository.findByUserId(user5.getId()).get();
 
-        mockMvc.perform(patch("/api/v1//admin/reservations/" + pending.getId())
+        mockMvc.perform(patch("/api/v1/admin/reservations/" + pending.getId())
                         .with(csrf()))
                 .andExpect(status().isNoContent());
 


### PR DESCRIPTION
## #️⃣ Issue Number
#35 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Admin 로그인과 User 로그인 모두 passwordEncoder를 빈으로 등록하여서 중복 등록 발생. AdminSecurityConfig의 `@Bean`만 남겨두고 UserLogin 쪽은 passwordEncoder를 주입받는 형식으로 통일했습니다.
- 예약 repository에 findByUserId 추가
- 예약검색 api 엔드포인트 변경사항 반영
- 자잘한 테스트 코드 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가
-   [x] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
