### PR TITLE
refactor(performance): 공연 리팩토링

### DIFF
--- a/backend/src/main/java/me/performancereservation/api/UserPerformanceController.java
+++ b/backend/src/main/java/me/performancereservation/api/UserPerformanceController.java
@@ -3,14 +3,17 @@ package me.performancereservation.api;
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.performance.dto.performance.response.PerformanceDetailResponse;
 import me.performancereservation.domain.performance.dto.performance.response.PerformancePageResponse;
+import me.performancereservation.domain.performance.enums.PerformanceCategory;
 import me.performancereservation.domain.performance.service.PerformanceScheduleService;
 import me.performancereservation.domain.performance.service.PerformanceService;
+import me.performancereservation.global.security.oauth.user.CustomOAuth2User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -42,8 +45,14 @@ public class UserPerformanceController {
      * @return 200 + performanceResponse
      */
     @GetMapping("/performances/{performanceId}")
-    public ResponseEntity<PerformanceDetailResponse> getPerformanceDetail(@PathVariable Long performanceId) {
-        PerformanceDetailResponse performanceResponse = performanceService.getPerformanceDetail(performanceId);
+    public ResponseEntity<PerformanceDetailResponse> getPerformanceDetail(@PathVariable Long performanceId,
+                                                                          @AuthenticationPrincipal CustomOAuth2User principal) {
+        Long userId = null;
+        if(principal != null) {
+            userId = principal.getUser().getId();
+        }
+
+        PerformanceDetailResponse performanceResponse = performanceService.getPerformanceDetail(performanceId, userId);
         return ResponseEntity.ok(performanceResponse);
     }
 
@@ -62,9 +71,10 @@ public class UserPerformanceController {
                                                                                @RequestParam(required = false) String venue,
                                                                                @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
                                                                                @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+                                                                               @RequestParam(required = false) PerformanceCategory category,
                                                                                Pageable pageable
     ) {
-        Page<PerformancePageResponse> performancePageResponse = performanceService.searchPerformances(title, venue, start, end, pageable);
+        Page<PerformancePageResponse> performancePageResponse = performanceService.searchPerformances(title, venue, start, end, category, pageable);
         return ResponseEntity.ok(performancePageResponse);
     }
 

--- a/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/admin/dto/AdminReservationPageResponse.java
@@ -17,9 +17,9 @@ import java.time.LocalDateTime;
  * @param createdAt 예약 생성 일시
  */
 public record AdminReservationPageResponse(
-        Long reservationId,
-        Long performanceId,
-        Long performanceScheduleId,
+        long reservationId,
+        long performanceId,
+        long performanceScheduleId,
         String name,
         String title,
         int price,

--- a/backend/src/main/java/me/performancereservation/domain/bookmark/BookmarkService.java
+++ b/backend/src/main/java/me/performancereservation/domain/bookmark/BookmarkService.java
@@ -127,7 +127,6 @@ public class BookmarkService {
                 performance.getStartDate(),
                 performance.getEndDate(),
                 performance.getVenue(),
-                performance.getDescription(),
                 performance.getCategory(),
                 performance.getStatus(),
                 true // 북마크 목록이므로 모두 북마크되어 있음

--- a/backend/src/main/java/me/performancereservation/domain/bookmark/dto/BookmarkedPerformancePageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/bookmark/dto/BookmarkedPerformancePageResponse.java
@@ -11,9 +11,9 @@ import java.time.LocalDateTime;
  * @param fileUrl
  * @param title
  * @param price
- * @param performanceDate
+ * @param startDate
+ * @param endDate
  * @param venue
- * @param description
  * @param category
  * @param status
  * @param bookmarked //북마크 되어있는지 여부
@@ -26,7 +26,6 @@ public record BookmarkedPerformancePageResponse(
         LocalDateTime startDate,
         LocalDateTime endDate,
         String venue,
-        String description,
         PerformanceCategory category,
         PerformanceStatus status,
         boolean bookmarked

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceDetailResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceDetailResponse.java
@@ -1,6 +1,7 @@
 package me.performancereservation.domain.performance.dto.performance.response;
 
 import me.performancereservation.domain.performance.dto.performanceschedule.PerformanceScheduleResponse;
+import me.performancereservation.domain.performance.enums.PerformanceStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,9 +25,10 @@ public record PerformanceDetailResponse(
         int totalSeats,
         String venue,
         String description,
-        String status,
+        PerformanceStatus status,
         String fileUrl,
         LocalDateTime startDate,
         LocalDateTime endDate,
+        boolean bookmarked,
         List<PerformanceScheduleResponse> schedules
         ) {}

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceDetailResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceDetailResponse.java
@@ -19,7 +19,7 @@ import java.util.List;
  * @param schedules     // 회차 정보
  */
 public record PerformanceDetailResponse(
-        Long id,
+        long id,
         String title,
         int price,
         int totalSeats,

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerDetailResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerDetailResponse.java
@@ -17,7 +17,7 @@ import java.util.List;
  * @param schedules
  */
 public record PerformanceManagerDetailResponse(
-        Long id,
+        long id,
         String fileUrl,
         String title,
         String venue,

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerDetailResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerDetailResponse.java
@@ -1,6 +1,7 @@
 package me.performancereservation.domain.performance.dto.performance.response;
 
 import me.performancereservation.domain.performance.dto.performanceschedule.PerformanceScheduleResponse;
+import me.performancereservation.domain.performance.enums.PerformanceStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,7 +21,7 @@ public record PerformanceManagerDetailResponse(
         String fileUrl,
         String title,
         String venue,
-        String status,
+        PerformanceStatus status,
         int totalSeats,
         LocalDateTime startDate,
         LocalDateTime endDate,

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerPageResponse.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
  * @param status    // 공연 등록 여부 (PENDING, CONFIRM 등)
  */
 public record PerformanceManagerPageResponse(
-        Long id,
+        long id,
         String fileUrl,
         String title,
         LocalDateTime startDate,

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerPageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformanceManagerPageResponse.java
@@ -1,5 +1,8 @@
 package me.performancereservation.domain.performance.dto.performance.response;
 
+import me.performancereservation.domain.performance.enums.PerformanceCategory;
+import me.performancereservation.domain.performance.enums.PerformanceStatus;
+
 import java.time.LocalDateTime;
 
 /** 공연 관리자 공연 목록 페이지 응답용
@@ -19,6 +22,7 @@ public record PerformanceManagerPageResponse(
         LocalDateTime startDate,
         LocalDateTime endDate,
         String venue,
-        String status
+        PerformanceStatus status,
+        PerformanceCategory category
 ) {
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformancePageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformancePageResponse.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
  * @param category
  */
 public record PerformancePageResponse(
-        Long id,
+        long id,
         String fileUrl,
         String title,
         int price,

--- a/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformancePageResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/dto/performance/response/PerformancePageResponse.java
@@ -1,5 +1,7 @@
 package me.performancereservation.domain.performance.dto.performance.response;
 
+import me.performancereservation.domain.performance.enums.PerformanceCategory;
+
 import java.time.LocalDateTime;
 
 /** 고객 공연 목록 페이지 응답용
@@ -11,6 +13,7 @@ import java.time.LocalDateTime;
  * @param startDate
  * @param endDate
  * @param venue
+ * @param category
  */
 public record PerformancePageResponse(
         Long id,
@@ -19,6 +22,7 @@ public record PerformancePageResponse(
         int price,
         LocalDateTime startDate,
         LocalDateTime endDate,
-        String venue
+        String venue,
+        PerformanceCategory category
 ) {
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/entities/Performance.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/entities/Performance.java
@@ -101,4 +101,8 @@ public class Performance extends BaseEntity {
         return this.status == PerformanceStatus.CONFIRMED;
 
     }
+
+    public void completePerformance() {
+        this.status = PerformanceStatus.COMPLETED;
+    }
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/mapper/PerformanceMapper.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/mapper/PerformanceMapper.java
@@ -44,7 +44,7 @@ public class PerformanceMapper {
      * @param schedules
      * @return PerformanceDetailResponse
      */
-    public static PerformanceDetailResponse toDetailResponse(Performance performance, String fileUrl, List<PerformanceSchedule> schedules) {
+    public static PerformanceDetailResponse toDetailResponse(Performance performance, String fileUrl, boolean bookmarked, List<PerformanceSchedule> schedules) {
         return new PerformanceDetailResponse(
                 performance.getId(),
                 performance.getTitle(),
@@ -52,10 +52,11 @@ public class PerformanceMapper {
                 performance.getTotalSeats(),
                 performance.getVenue(),
                 performance.getDescription(),
-                performance.getStatus().toString(),
+                performance.getStatus(),
                 fileUrl,
                 performance.getStartDate(),
                 performance.getEndDate(),
+                bookmarked,
                 schedules.stream().map(PerformanceScheduleMapper::toResponse).toList()
         );
     }
@@ -74,7 +75,8 @@ public class PerformanceMapper {
                 performance.getPrice(),
                 performance.getStartDate(),
                 performance.getEndDate(),
-                performance.getVenue()
+                performance.getVenue(),
+                performance.getCategory()
         );
     }
 
@@ -92,7 +94,8 @@ public class PerformanceMapper {
                 performance.getStartDate(),
                 performance.getEndDate(),
                 performance.getVenue(),
-                performance.getStatus().toString()
+                performance.getStatus(),
+                performance.getCategory()
         );
     }
 
@@ -110,7 +113,7 @@ public class PerformanceMapper {
                 fileUrl,
                 performance.getTitle(),
                 performance.getVenue(),
-                performance.getStatus().toString(),
+                performance.getStatus(),
                 performance.getTotalSeats(),
                 performance.getStartDate(),
                 performance.getEndDate(),

--- a/backend/src/main/java/me/performancereservation/domain/performance/repository/PerformanceRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/repository/PerformanceRepository.java
@@ -1,6 +1,7 @@
 package me.performancereservation.domain.performance.repository;
 
 import me.performancereservation.domain.performance.entities.Performance;
+import me.performancereservation.domain.performance.enums.PerformanceCategory;
 import me.performancereservation.domain.performance.enums.PerformanceStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PerformanceRepository extends JpaRepository<Performance, Long> {
     Page<Performance> findByManagerId(Long managerId, Pageable pageable);
@@ -43,6 +45,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     JOIN PerformanceSchedule ps ON p.id = ps.performanceId
     WHERE ps.remainingSeats > 0
     AND p.status = 'CONFIRMED'
+    AND (:category IS NULL OR p.status = :category)
     AND (:title IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :title, '%')))
     AND (:venue IS NULL OR LOWER(p.venue) LIKE LOWER(CONCAT('%', :venue, '%')))
     AND (:start IS NULL OR p.endDate >= :start)
@@ -54,6 +57,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             @Param("venue") String venue,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end,
+            @Param("category") PerformanceCategory category,
             Pageable pageable
     );
 
@@ -89,4 +93,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             @Param("end") LocalDateTime end,
             Pageable pageable
     );
+
+    // 종료일 지났고 종료처리 되지 않은 공연을 가져오는 메서드
+    List<Performance> findByEndDateBeforeAndStatus(LocalDateTime endDate, PerformanceStatus status);
 }

--- a/backend/src/main/java/me/performancereservation/domain/performance/scheduler/PerformanceScheduler.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/scheduler/PerformanceScheduler.java
@@ -1,0 +1,18 @@
+package me.performancereservation.domain.performance.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import me.performancereservation.domain.performance.service.PerformanceService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PerformanceScheduler {
+
+    private final PerformanceService performanceService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void completeEndedPerformances() {
+        performanceService.completeEndedPerformances();
+    }
+}

--- a/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
@@ -2,6 +2,7 @@ package me.performancereservation.domain.performance.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.performancereservation.domain.bookmark.BookmarkRepository;
 import me.performancereservation.domain.file.File;
 import me.performancereservation.domain.file.FileRepository;
 import me.performancereservation.domain.performance.dto.performance.request.PerformanceCreateRequest;
@@ -13,6 +14,7 @@ import me.performancereservation.domain.performance.dto.performance.response.Per
 import me.performancereservation.domain.performance.dto.performanceschedule.PerformanceScheduleResponse;
 import me.performancereservation.domain.performance.entities.Performance;
 import me.performancereservation.domain.performance.entities.PerformanceSchedule;
+import me.performancereservation.domain.performance.enums.PerformanceCategory;
 import me.performancereservation.domain.performance.enums.PerformanceStatus;
 import me.performancereservation.domain.performance.event.PerformanceCanceledEvent;
 import me.performancereservation.domain.performance.mapper.PerformanceMapper;
@@ -39,6 +41,7 @@ public class PerformanceService {
 
     private final PerformanceRepository performanceRepository;
     private final PerformanceScheduleRepository performanceScheduleRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final FileRepository fileRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -134,7 +137,7 @@ public class PerformanceService {
      * @return PerformanceDetailResponse
      */
     @Transactional(readOnly = true)
-    public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {
+    public PerformanceDetailResponse getPerformanceDetail(Long performanceId, Long userId) {
         // 공연 조회
         Performance performance = performanceRepository.findById(performanceId)
                 .orElseThrow(() -> ErrorCode.PERFORMANCE_NOT_FOUND.domainException("해당하는 공연을 찾을 수 없습니다. id=" + performanceId));
@@ -143,15 +146,19 @@ public class PerformanceService {
         List<PerformanceSchedule> schedules = performanceScheduleRepository
                 .findByPerformanceId(performance.getId());
 
+        boolean bookmarked = false;
+        if(userId != null) {
+            bookmarked = bookmarkRepository.existsByUserIdAndPerformanceId(userId, performanceId);
+        }
         // 파일이 존재하는지
         if (!performance.hasFile()) {
-            return PerformanceMapper.toDetailResponse(performance, null, schedules);
+            return PerformanceMapper.toDetailResponse(performance, null, bookmarked, schedules);
         } else {
             // 파일이 존재한다면 조회
             File file = fileRepository.findById(performance.getFileId())
                     .orElseThrow(() -> ErrorCode.FILE_NOT_FOUND.domainException("해당하는 파일을 찾을 수 없습니다. id=" + performance.getFileId()));
 
-            return PerformanceMapper.toDetailResponse(performance, file.getKey(), schedules);
+            return PerformanceMapper.toDetailResponse(performance, file.getKey(), bookmarked, schedules);
         }
     }
 
@@ -226,8 +233,9 @@ public class PerformanceService {
                                                             String venue,
                                                             LocalDateTime start,
                                                             LocalDateTime end,
+                                                            PerformanceCategory category,
                                                             Pageable pageable) {
-        Page<Performance> performances = performanceRepository.searchAvailablePerformances(title, venue, start, end, pageable);
+        Page<Performance> performances = performanceRepository.searchAvailablePerformances(title, venue, start, end, category, pageable);
 
         List<Long> fileIds = getFileIdList(performances);
 
@@ -264,6 +272,18 @@ public class PerformanceService {
 
         return performances.map(performance ->
                 PerformanceMapper.toManagerListResponse(performance, fileUrlMap.get(performance.getFileId())));
+    }
+
+    /** 매일 00시 정각에 스케줄러에 의해 실행되는 공연 종료 처리 메서드
+     *
+     */
+    @Transactional
+    public void completeEndedPerformances() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Performance> endedPerformances = performanceRepository.findByEndDateBeforeAndStatus(now, PerformanceStatus.CONFIRMED);
+
+        endedPerformances.forEach(Performance::completePerformance);
+
     }
 
     // 파일 Url 맵 변환 메서드

--- a/backend/src/test/java/me/performancereservation/domain/admin/service/AdminPerformanceServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/admin/service/AdminPerformanceServiceTest.java
@@ -84,7 +84,8 @@ class AdminPerformanceServiceTest {
                 .price(10000)
                 .totalSeats(100)
                 .category(PerformanceCategory.OPERA)
-                .performanceDate(LocalDateTime.now().plusDays(7))
+                .startDate(LocalDateTime.now().plusDays(7))
+                .endDate(LocalDateTime.now().plusDays(8))
                 .description("테스트 설명")
                 .status(PerformanceStatus.PENDING)
                 .build();
@@ -96,7 +97,7 @@ class AdminPerformanceServiceTest {
                 .startTime(LocalDateTime.now().plusDays(7))
                 .endTime(LocalDateTime.now().plusDays(7).plusHours(2))
                 .remainingSeats(100)
-                .is_canceled(false)
+                .canceled(false)
                 .build();
 
         // 파일 생성
@@ -131,6 +132,7 @@ class AdminPerformanceServiceTest {
                 100,
                 PerformanceCategory.OPERA,
                 LocalDateTime.now().plusDays(7),
+                LocalDateTime.now().plusDays(8),
                 "테스트 설명",
                 List.of(scheduleResponse)
         );

--- a/backend/src/test/java/me/performancereservation/domain/bookmark/BookmarkServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/bookmark/BookmarkServiceTest.java
@@ -234,7 +234,8 @@ class BookmarkServiceTest {
                         .description("테스트 설명 1")
                         .category(PerformanceCategory.OPERA)
                         .status(PerformanceStatus.CONFIRMED)
-                        .performanceDate(LocalDateTime.now().plusDays(1))
+                        .startDate(LocalDateTime.now().plusDays(1))
+                        .endDate(LocalDateTime.now().plusDays(2))
                         .build(),
                 Performance.builder()
                         .id(2L)
@@ -245,7 +246,8 @@ class BookmarkServiceTest {
                         .description("테스트 설명 2")
                         .category(PerformanceCategory.OPERA)
                         .status(PerformanceStatus.CONFIRMED)
-                        .performanceDate(LocalDateTime.now().plusDays(2))
+                        .startDate(LocalDateTime.now().plusDays(2))
+                        .endDate(LocalDateTime.now().plusDays(3))
                         .build()
         );
 

--- a/backend/src/test/java/me/performancereservation/domain/bookmark/BookmarkServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/bookmark/BookmarkServiceTest.java
@@ -276,7 +276,6 @@ class BookmarkServiceTest {
         assertEquals("테스트 공연 1", response1.title());
         assertEquals(10000, response1.price());
         assertEquals("테스트 장소 1", response1.venue());
-        assertEquals("테스트 설명 1", response1.description());
         assertEquals(PerformanceCategory.OPERA, response1.category());
         assertEquals(PerformanceStatus.CONFIRMED, response1.status());
         assertTrue(response1.bookmarked());
@@ -287,7 +286,6 @@ class BookmarkServiceTest {
         assertEquals("테스트 공연 2", response2.title());
         assertEquals(20000, response2.price());
         assertEquals("테스트 장소 2", response2.venue());
-        assertEquals("테스트 설명 2", response2.description());
         assertEquals(PerformanceCategory.OPERA, response2.category());
         assertEquals(PerformanceStatus.CONFIRMED, response2.status());
         assertTrue(response2.bookmarked());

--- a/backend/src/test/java/me/performancereservation/domain/performance/service/PerformanceServiceTest.java
+++ b/backend/src/test/java/me/performancereservation/domain/performance/service/PerformanceServiceTest.java
@@ -334,7 +334,7 @@ class PerformanceServiceTest {
         when(performanceScheduleRepository.findByPerformanceId(PERFORMANCE_ID1)).thenReturn(List.of(schedule1, schedule2, schedule3));
 
         //when
-        PerformanceDetailResponse response = performanceService.getPerformanceDetail(PERFORMANCE_ID1);
+        PerformanceDetailResponse response = performanceService.getPerformanceDetail(PERFORMANCE_ID1, null);
 
         //then
         assertThat(response.id()).isEqualTo(PERFORMANCE_ID1);
@@ -349,7 +349,7 @@ class PerformanceServiceTest {
         when(performanceRepository.findById(PERFORMANCE_ID1)).thenReturn(Optional.empty());
 
         //when & then
-        assertThatThrownBy(() -> performanceService.getPerformanceDetail(PERFORMANCE_ID1))
+        assertThatThrownBy(() -> performanceService.getPerformanceDetail(PERFORMANCE_ID1, null))
                 .isInstanceOf(AppException.class)
                 .hasMessageContaining("해당 공연을 찾을 수 없습니다.");
     }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### 북마크 기능 반영
- 고객 공연 상세 페이지 조회 시 북마크 정보를 함께 넣어 보내도록 수정
- 비로그인 시 항상 false
- 로그인 시 북마크 여부 조회 후 응답에 포함 

### 스케줄러 추가
- 매일 00시 기준 공연 종료 처리 스케줄러 추가
- 00시를 기준으로 endDate가 현재 날짜 보다 전이고 공연중 상태인 공연을 가져와 종료 처리 수행
- 현재는 간단하게 공연 상태를 COMPLETED로 변경하는 기능만 수행
- 검증 로직을 넣을까 하다가 이미 쿼리로 공연중 상태만 들고 왔기 때문에 별도의 검증은 존재하지 않는 상태

### 검색 필터 추가 - 카테고리
- 기존 목록 응답 시 카테고리 필드를 넣어 보내지 않았는데 카테고리 필드도 응답에 추가해 보내도록 변경
- 고객이 카테고리 탭을 통해 카테고리에 맞는 공연만 볼 수 있으면 좋을 것 같아 검색 로직에 카테고리 필터 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
### 여담?
치연님이 만들어주신 북마크한 공연 목록 응답 dto에 설명 필드인 description이 들어있던데 목록을 띄울 때 설명도 같이 출력을 염두하고 만들어 두신 걸까요? 
저는 멜론티켓 사이트에서 공연 목록을 봤을 때 이런식으로
![image](https://github.com/user-attachments/assets/7ee29a3b-61b7-45d1-a481-8594cc1d879b)
목록에는 설명이 없고 설명은 상세 페이지에서만 보여주는 걸 생각 했는데 목록 응답 dto 형식을 통일 하는 게 좋을까요?
아니면 북마크라는 게 내가 눈여겨보고 있다는 뜻이니 기존 목록보다 좀 더 추가 정보를 보여주게 지금처럼 형식을 다르게 두는 게 나을까요?

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
