### PR TITLE
feat(performance): 공연 종료 시 좌석 정보 제거 하는 기능 추가

### DIFF
--- a/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
@@ -22,6 +22,7 @@ import me.performancereservation.domain.performance.mapper.PerformanceScheduleMa
 import me.performancereservation.domain.performance.repository.PerformanceRepository;
 import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
 import me.performancereservation.global.exception.ErrorCode;
+import me.performancereservation.global.storage.redis.RedisSeatService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,6 +45,8 @@ public class PerformanceService {
     private final BookmarkRepository bookmarkRepository;
     private final FileRepository fileRepository;
     private final ApplicationEventPublisher eventPublisher;
+
+    private final RedisSeatService redisSeatService;
 
     /** 공연 등록 요청
      *
@@ -279,10 +282,20 @@ public class PerformanceService {
      */
     @Transactional
     public void completeEndedPerformances() {
+        // 공연 취소 상태로 변경
         LocalDateTime now = LocalDateTime.now();
         List<Performance> endedPerformances = performanceRepository.findByEndDateBeforeAndStatus(now, PerformanceStatus.CONFIRMED);
 
-        endedPerformances.forEach(Performance::completePerformance);
+        // 레디스 회차별 좌석 정보 제거
+        endedPerformances.forEach(performance ->{
+            performance.completePerformance();
+
+            List<PerformanceSchedule> schedules = performanceScheduleRepository.findByPerformanceId(performance.getId());
+
+            schedules.forEach(schedule -> {
+                redisSeatService.deleteSeatStock(schedule.getId());
+            });
+        });
 
     }
 

--- a/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
@@ -282,7 +282,7 @@ public class PerformanceService {
      */
     @Transactional
     public void completeEndedPerformances() {
-        // 공연 취소 상태로 변경
+        // 공연 완료 상태로 변경
         LocalDateTime now = LocalDateTime.now();
         List<Performance> endedPerformances = performanceRepository.findByEndDateBeforeAndStatus(now, PerformanceStatus.CONFIRMED);
 

--- a/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationRequest.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationRequest.java
@@ -7,6 +7,6 @@ import jakarta.validation.constraints.Positive;
  * 유저의 예약 시도를 위한 요청 Dto
  */
 public record ReservationRequest(
-        @NotNull long scheduleId, // 공연 회차 ID
+        @NotNull Long scheduleId, // 공연 회차 ID
         @NotNull @Positive int quantity // 티켓수량
 ) {}


### PR DESCRIPTION
## 📝 요약(Summary)
공연 종료 시, 레디스에 저장되어있는 공연 회차별 좌석 정보들도 제거하도록 수정했습니다

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제
