### PR TITLE
refactor(reservation): 어드민 공연취소에 따른 예약 일괄취소 api 위치 이동

### DIFF
--- a/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/AdminReservationController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.admin.dto.AdminReservationPageResponse;
 import me.performancereservation.domain.admin.service.AdminReservationService;
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
+import me.performancereservation.domain.reservation.service.redis.RedisReservationBulkCancelService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 public class AdminReservationController {
 
     private final AdminReservationService adminReservationService;
+    private final RedisReservationBulkCancelService bulkCancelService;
 
     /** 예약 목록 조회 매핑
      *
@@ -67,4 +69,15 @@ public class AdminReservationController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 공연 ID 기준으로 예약 일괄 취소를 수동으로 수행
+     *
+     * @param performanceId 공연 id
+     */
+    @PostMapping("/cancel/{performanceId}")
+    public ResponseEntity<Void> bulkCancelByPerformanceId(@PathVariable Long performanceId) {
+        bulkCancelService.cancelAllByPerformanceId(performanceId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/me/performancereservation/api/ReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/ReservationController.java
@@ -76,13 +76,4 @@ public class ReservationController {
                 authentication.getUser().getId()
         ));
     }
-
-    // 공연 ID 기준으로 예약 일괄 취소를 수동으로 수행
-    @PostMapping("/cancel/{performanceId}")
-    // TODO 어드민 권한 부착하거나 어드민 컨트롤러 구현되면 그쪽으로 이동
-    public ResponseEntity<Void> bulkCancelByPerformanceId(@PathVariable Long performanceId) {
-        bulkCancelService.cancelAllByPerformanceId(performanceId);
-
-        return ResponseEntity.noContent().build();
-    }
 }


### PR DESCRIPTION

## 📝 요약(Summary)
어드민 공연취소에 따른 예약 일괄취소 api 를 유저 예약 컨트롤러에서 어드민 예약 컨트롤러로 이동했습니다

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

