### PR TITLE
feat(reservation, ticket): 티켓 도메인 추가, 예약할 때 티켓 생성, 공연 취소, 만료 시 티켓 처리

### DIFF
--- a/backend/src/main/java/me/performancereservation/api/ReservationController.java
+++ b/backend/src/main/java/me/performancereservation/api/ReservationController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ReservationController implements ReservationApiDocs {
     private final RedisSeatReservationService seatReservationService;
-    private final RedisReservationBulkCancelService bulkCancelService;
     private final ReservationQueryService reservationQueryService;
 
     @Override
@@ -34,6 +33,7 @@ public class ReservationController implements ReservationApiDocs {
             @AuthenticationPrincipal CustomOAuth2User authentication
     ) {
         ReservationResponse result = seatReservationService.reserve(
+                request.performanceId(),
                 request.scheduleId(),
                 authentication.getUser().getId(),
                 request.quantity()

--- a/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
+++ b/backend/src/main/java/me/performancereservation/domain/performance/service/PerformanceService.java
@@ -21,6 +21,8 @@ import me.performancereservation.domain.performance.mapper.PerformanceMapper;
 import me.performancereservation.domain.performance.mapper.PerformanceScheduleMapper;
 import me.performancereservation.domain.performance.repository.PerformanceRepository;
 import me.performancereservation.domain.performance.repository.PerformanceScheduleRepository;
+import me.performancereservation.domain.ticket.Ticket;
+import me.performancereservation.domain.ticket.TicketRepository;
 import me.performancereservation.global.exception.ErrorCode;
 import me.performancereservation.global.storage.redis.RedisSeatService;
 import org.springframework.context.ApplicationEventPublisher;
@@ -44,6 +46,8 @@ public class PerformanceService {
     private final PerformanceScheduleRepository performanceScheduleRepository;
     private final BookmarkRepository bookmarkRepository;
     private final FileRepository fileRepository;
+    private final TicketRepository ticketRepository;
+
     private final ApplicationEventPublisher eventPublisher;
 
     private final RedisSeatService redisSeatService;
@@ -290,13 +294,18 @@ public class PerformanceService {
         endedPerformances.forEach(performance ->{
             performance.completePerformance();
 
+            // 티켓 만료 처리
+            List<Ticket> tickets = ticketRepository.findAllByPerformanceId(performance.getId());
+
+            tickets.forEach(Ticket::expire);
+
+            // 레디스 좌석 정보 제거
             List<PerformanceSchedule> schedules = performanceScheduleRepository.findByPerformanceId(performance.getId());
 
             schedules.forEach(schedule -> {
                 redisSeatService.deleteSeatStock(schedule.getId());
             });
         });
-
     }
 
     // 파일 Url 맵 변환 메서드

--- a/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/Reservation.java
@@ -18,6 +18,8 @@ public class Reservation extends BaseEntity {
 
     private Long userId; // (FK) 유저 ID
 
+    private Long performanceId; // (FK) 공연 ID
+
     private Long scheduleId; // (FK) 공연회차 ID
 
     private int quantity; // 티켓 수량
@@ -31,9 +33,10 @@ public class Reservation extends BaseEntity {
     }
 
     @Builder
-    public Reservation(Long id, Long userId, Long scheduleId, int quantity, ReservationStatus status) {
+    public Reservation(Long id, Long userId, Long performanceId, Long scheduleId, int quantity, ReservationStatus status) {
         this.id = id;
         this.userId = userId;
+        this.performanceId = performanceId;
         this.scheduleId = scheduleId;
         this.quantity = quantity;
         this.status = status;

--- a/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationRequest.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Positive;
  * 유저의 예약 시도를 위한 요청 Dto
  */
 public record ReservationRequest(
+        @NotNull Long performanceId, // 공연 ID
         @NotNull Long scheduleId, // 공연 회차 ID
         @NotNull @Positive int quantity // 티켓수량
 ) {}

--- a/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationResponse.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/dto/ReservationResponse.java
@@ -3,6 +3,7 @@ package me.performancereservation.domain.reservation.dto;
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 예약 정보 응답 Dto
@@ -16,5 +17,6 @@ public record ReservationResponse(
         LocalDateTime createdAt, // 예약 신청 일시
         LocalDateTime expirationAt, // 결제 만료 일시
         int ticketPrice, // 티켓 가격
-        int totalPrice // 총 결제 금액
+        int totalPrice, // 총 결제 금액
+        List<String> ticketNumbers // 티켓 번호 목록
 ) {}

--- a/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/mapper/ReservationMapper.java
@@ -5,14 +5,19 @@ import me.performancereservation.domain.performance.model.SchedulePerformanceInf
 import me.performancereservation.domain.reservation.Reservation;
 import me.performancereservation.domain.reservation.dto.ReservationPageResponse;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
+import me.performancereservation.domain.ticket.Ticket;
+import me.performancereservation.domain.ticket.TicketRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class ReservationMapper {
+    private final TicketRepository ticketRepository;
+
     @Value("${reservation.expired_time}")
     private int EXPIRE_MINUTES;
 
@@ -29,6 +34,14 @@ public class ReservationMapper {
 
         int totalPrice = reservation.calculateTotalPrice(schedulePerformanceInfo.price());
 
+        // 관련 티켓들 조회
+        List<Ticket> tickets = ticketRepository.findAllByReservationId(reservation.getId());
+
+        // 티켓 id 목록 생성
+        List<String> ticketNumbers = tickets.stream()
+                .map(ticket -> reservation.getId() + "-" + ticket.getId().toString())
+                .toList();
+
         return new ReservationResponse(
                 reservation.getId(),
                 schedulePerformanceInfo.title(),
@@ -38,7 +51,8 @@ public class ReservationMapper {
                 createdAt,
                 expirationAt,
                 schedulePerformanceInfo.price(),
-                totalPrice
+                totalPrice,
+                ticketNumbers
         );
     }
 

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/SeatReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/SeatReservationService.java
@@ -3,7 +3,7 @@ package me.performancereservation.domain.reservation.service;
 import me.performancereservation.domain.reservation.dto.ReservationResponse;
 
 public interface SeatReservationService {
-    ReservationResponse reserve(Long scheduleId, Long userId, int quantity);
+    ReservationResponse reserve(Long performanceId, Long scheduleId, Long userId, int quantity);
 
     void cancel(Long scheduleId, Long userId);
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationCancelExecutor.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisReservationCancelExecutor.java
@@ -3,9 +3,13 @@ package me.performancereservation.domain.reservation.service.redis;
 import lombok.RequiredArgsConstructor;
 import me.performancereservation.domain.refund.RefundService;
 import me.performancereservation.domain.reservation.Reservation;
+import me.performancereservation.domain.ticket.Ticket;
+import me.performancereservation.domain.ticket.TicketRepository;
 import me.performancereservation.global.storage.redis.RedisReservationService;
 import me.performancereservation.global.storage.redis.RedisSeatService;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 /**
  * 예약 취소 로직 실행기
@@ -17,6 +21,8 @@ public class RedisReservationCancelExecutor {
     private final RefundService refundService;
     private final RedisSeatService redisSeatService;
     private final RedisReservationService redisReservationService;
+
+    private final TicketRepository ticketRepository;
 
     // 유저가 취소했을 경우 (레디스 좌석 롤백 필요)
     public void executeForUserCancel(Reservation reservation) {
@@ -49,5 +55,10 @@ public class RedisReservationCancelExecutor {
 
         // 예약 만료 처리 대기 큐에서도 제거
         redisReservationService.removeFromPendingExpirationQueue(reservation.getId());
+
+        // 티켓 취소
+        List<Ticket> tickets = ticketRepository.findAllByReservationId(reservation.getId());
+
+        tickets.forEach(Ticket::cancel);
     }
 }

--- a/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationService.java
+++ b/backend/src/main/java/me/performancereservation/domain/reservation/service/redis/RedisSeatReservationService.java
@@ -11,6 +11,9 @@ import me.performancereservation.domain.reservation.dto.ReservationResponse;
 import me.performancereservation.domain.reservation.enums.ReservationStatus;
 import me.performancereservation.domain.reservation.mapper.ReservationMapper;
 import me.performancereservation.domain.reservation.service.SeatReservationService;
+import me.performancereservation.domain.ticket.Ticket;
+import me.performancereservation.domain.ticket.TicketRepository;
+import me.performancereservation.domain.ticket.enums.TicketStatus;
 import me.performancereservation.global.exception.ErrorCode;
 import me.performancereservation.global.storage.redis.RedisReservationService;
 import me.performancereservation.global.storage.redis.RedisSeatService;
@@ -25,6 +28,7 @@ import org.springframework.stereotype.Service;
 public class RedisSeatReservationService implements SeatReservationService {
     private final ReservationRepository reservationRepository;
     private final PerformanceScheduleRepository performanceScheduleRepository;
+    private final TicketRepository ticketRepository;
 
     private final RedisSeatService redisSeatService;
     private final RedisReservationService redisReservationService;
@@ -45,6 +49,7 @@ public class RedisSeatReservationService implements SeatReservationService {
      *
      * TODO 추후 어드민 무통장 결제 승인 메서드에서 티켓 수량만큼을 해당 Schedule에 차감 반영해야함
      *
+     * @param performanceId 공연 ID
      * @param scheduleId 공연 회차 ID
      * @param userId 예약하는 유저 ID
      * @param quantity 예약한 티켓 수
@@ -52,13 +57,14 @@ public class RedisSeatReservationService implements SeatReservationService {
      */
     @Override
     @Transactional
-    public ReservationResponse reserve(Long scheduleId, Long userId, int quantity) {
+    public ReservationResponse reserve(Long performanceId, Long scheduleId, Long userId, int quantity) {
         // Redis에서 좌석 1개 먼저 차감 (RDB 접근 없이 선 예약 선점 - 빠른 필터링이 가능한게 장점)
         redisSeatService.safeDecrement(scheduleId, quantity); // 내부에 Redis 좌석 선점 관련 예외처리 있음
 
         // 예약 엔티티 저장 (status -> PAYMENTS_PENDING (결제 대기))
         Reservation reservation = reservationRepository.save(
                 Reservation.builder()
+                        .performanceId(performanceId)
                         .scheduleId(scheduleId)
                         .userId(userId)
                         .quantity(quantity)
@@ -69,6 +75,16 @@ public class RedisSeatReservationService implements SeatReservationService {
         // 결제 대기 중인 예약에 대한 결제 만료 시간을 Redis ZSet에 등록
         // ReservationExpirationScheduler가 주기적으로 조회해서 만료 시간 초과 시 예약을 자동 취소
         redisReservationService.addToPendingExpirationQueue(reservation.getId());
+
+        // 티켓 수량만큼 생성
+        for (int i = 0; i < quantity; i++) {
+            ticketRepository.save(Ticket.builder()
+                    .reservationId(reservation.getId())
+                    .performanceId(performanceId)
+                    .ticketStatus(TicketStatus.PENDING)
+                    .build()
+            );
+        }
 
         // response dto mapping용도로 schedulePerformanceInfo 데이터 모델 조회
         SchedulePerformanceInfo schedulePerformanceInfo = performanceScheduleRepository.findSchedulePerformanceInfoByScheduleId(scheduleId)

--- a/backend/src/main/java/me/performancereservation/domain/ticket/Ticket.java
+++ b/backend/src/main/java/me/performancereservation/domain/ticket/Ticket.java
@@ -1,0 +1,44 @@
+package me.performancereservation.domain.ticket;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.performancereservation.domain.ticket.enums.TicketStatus;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ticket {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 티켓 id
+
+    private Long reservationId; // 예약 id
+
+    private Long performanceId; // 공연 id
+
+    @Enumerated(EnumType.STRING)
+    private TicketStatus ticketStatus; // 티켓 상태
+
+    @Builder
+    public Ticket(Long id, Long reservationId, Long performanceId, TicketStatus ticketStatus) {
+        this.id = id;
+        this.reservationId = reservationId;
+        this.performanceId = performanceId;
+        this.ticketStatus = ticketStatus;
+    }
+
+    public void cancel(){
+        this.ticketStatus = TicketStatus.CANCELLED;
+    }
+
+    public void use(){
+        this.ticketStatus = TicketStatus.USED;
+    }
+
+    public void expire(){
+        this.ticketStatus = TicketStatus.EXPIRED;
+    }
+}

--- a/backend/src/main/java/me/performancereservation/domain/ticket/TicketRepository.java
+++ b/backend/src/main/java/me/performancereservation/domain/ticket/TicketRepository.java
@@ -1,0 +1,11 @@
+package me.performancereservation.domain.ticket;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    List<Ticket> findAllByReservationId(Long reservationId);
+
+    List<Ticket> findAllByPerformanceId(Long performanceId);
+}

--- a/backend/src/main/java/me/performancereservation/domain/ticket/TicketService.java
+++ b/backend/src/main/java/me/performancereservation/domain/ticket/TicketService.java
@@ -1,0 +1,13 @@
+package me.performancereservation.domain.ticket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+    private final TicketRepository ticketRepository;
+
+
+
+}

--- a/backend/src/main/java/me/performancereservation/domain/ticket/enums/TicketStatus.java
+++ b/backend/src/main/java/me/performancereservation/domain/ticket/enums/TicketStatus.java
@@ -1,0 +1,8 @@
+package me.performancereservation.domain.ticket.enums;
+
+public enum TicketStatus {
+    PENDING, // 티켓 사용 전
+    USED, // 티켓 사용 완료
+    CANCELLED, // 취소
+    EXPIRED // 만료
+}

--- a/backend/src/main/java/me/performancereservation/global/init/MockDataLoader.java
+++ b/backend/src/main/java/me/performancereservation/global/init/MockDataLoader.java
@@ -58,8 +58,8 @@ public class MockDataLoader implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        // Redis 초기화
-        redisTemplate.getConnectionFactory().getConnection().flushAll();
+//        // Redis 초기화
+//        redisTemplate.getConnectionFactory().getConnection().flushAll();
 
         try {
             // User 생성
@@ -357,6 +357,7 @@ public class MockDataLoader implements CommandLineRunner {
 
             reservations.add(Reservation.builder()
                     .userId(user.getId())
+                    .performanceId(schedule.getPerformanceId())
                     .scheduleId(schedule.getId())
                     .quantity(1 + i)
                     .status(ReservationStatus.PAYMENTS_PENDING)
@@ -370,6 +371,7 @@ public class MockDataLoader implements CommandLineRunner {
 
             reservations.add(Reservation.builder()
                     .userId(user.getId())
+                    .performanceId(schedule.getPerformanceId())
                     .scheduleId(schedule.getId())
                     .quantity(2 + i)
                     .status(ReservationStatus.PAYMENTS_CONFIRMED)
@@ -383,6 +385,7 @@ public class MockDataLoader implements CommandLineRunner {
 
             reservations.add(Reservation.builder()
                     .userId(user.getId())
+                    .performanceId(schedule.getPerformanceId())
                     .scheduleId(schedule.getId())
                     .quantity(1 + i)
                     .status(ReservationStatus.CANCEL_PENDING)
@@ -396,6 +399,7 @@ public class MockDataLoader implements CommandLineRunner {
 
             reservations.add(Reservation.builder()
                     .userId(user.getId())
+                    .performanceId(schedule.getPerformanceId())
                     .scheduleId(schedule.getId())
                     .quantity(2 + i)
                     .status(ReservationStatus.CANCEL_CONFIRMED)


### PR DESCRIPTION
## #️⃣ Issue Number
#95 

## 📝 요약(Summary)
티켓 도메인 추가, 예약할 때 티켓 생성, 공연 취소, 만료 시 티켓 처리

예약 엔티티에 performanceId 필드 추가 (개발 편의성 향상 목적)

MockData 생성기 레디스 초기화 하는 부분 주석처리함 (레디스에 있는 좌석 정보가 초기화 되면 예약을 할 수 없음)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
예약을 할 때, 상세 예약을 조회할 때 
responseDto에 ticketNumbers 추가 됐습니다.

예약 완료 페이지나 상세 예약 조회 페이지에서 ticketNumbers를 띄우면 돼요

```
{
	"reservationId": 184,
	"title": "완료된 공연 3",
	"venue": "인천 연수구 공연장 3",
	"quantity": 3,
	"status": "PAYMENTS_PENDING",
	"createdAt": "2025-05-18T20:50:01.595803",
	"expirationAt": "2025-05-18T20:51:01.595803",
	"ticketPrice": 35000,
	"totalPrice": 105000,


        //  ticketNumbers 추가
	"ticketNumbers": [
		"184-4",
		"184-5",
		"184-6"
	] 
}
```

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
-   [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
