### PR TITLE
fix: 강제로 타임존을 asia/seoul로 고정

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,6 +6,10 @@ import { Performance } from '@/src/api/performance'
 import { Hero } from '@/components/hero'
 import { RecommendedPerformances } from '@/components/recommended-performances'
 import { getPerformanceImageUrl } from '@/lib/utils'
+import { formatKSTDateTime } from "@/src/utils/date";
+import { Calendar } from "lucide-react";
+import { CardContent } from "@/components/ui/card";
+
 interface PerformanceWithImage extends Performance {
   image: string
 }

--- a/frontend/app/performances/[performanceId]/client.tsx
+++ b/frontend/app/performances/[performanceId]/client.tsx
@@ -34,6 +34,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
+import { formatKSTDate, formatKSTDateTime } from "@/src/utils/date";
 
 interface PerformanceSchedule {
     id: number;
@@ -404,9 +405,7 @@ export default function PerformanceDetailClient({
     // KST로 시간 변환
     const formatTimeToKST = (dateString: string) => {
         try {
-            const date = parseISO(dateString);
-            const kstDate = addHours(date, 9); // UTC to KST
-            return format(kstDate, "yyyy.MM.dd HH:mm", { locale: ko });
+            return formatKSTDateTime(dateString);
         } catch (error) {
             return "날짜 정보 없음";
         }
@@ -419,11 +418,7 @@ export default function PerformanceDetailClient({
         }
 
         try {
-            const date = parseISO(dateString);
-            const kstDate = addHours(date, 9); // UTC to KST
-            return format(kstDate, "yyyy년 MM월 dd일 HH:mm", {
-                locale: ko,
-            });
+            return formatKSTDate(dateString);
         } catch (error) {
             console.error("날짜 파싱 오류:", error);
             return "날짜 정보 없음";
@@ -552,11 +547,11 @@ export default function PerformanceDetailClient({
                                                             공연 기간
                                                         </div>
                                                         <div className="text-sm text-muted-foreground">
-                                                            {formatTimeToKST(
+                                                            {formatKSTDate(
                                                                 performance.startDate
                                                             )}{" "}
                                                             ~{" "}
-                                                            {formatTimeToKST(
+                                                            {formatKSTDate(
                                                                 performance.endDate
                                                             )}
                                                         </div>
@@ -657,13 +652,13 @@ export default function PerformanceDetailClient({
                                     <div className="mt-2 text-muted-foreground">
                                         <p>
                                             시작일:{" "}
-                                            {formatTimeToKST(
+                                            {formatKSTDateTime(
                                                 performance.startDate
                                             )}
                                         </p>
                                         <p>
                                             종료일:{" "}
-                                            {formatTimeToKST(
+                                            {formatKSTDateTime(
                                                 performance.endDate
                                             )}
                                         </p>

--- a/frontend/app/performances/[performanceId]/page.tsx
+++ b/frontend/app/performances/[performanceId]/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({ params }: PageProps<PerformanceParams>)
 
 export default async function PerformanceDetailPage({ params }: PageProps<PerformanceParams>) {
   const { performanceId } = await params
-  return (
+    return (
     <Suspense fallback={
       <div className="container py-8 flex items-center justify-center min-h-[50vh]">
         <div className="flex flex-col items-center">

--- a/frontend/app/performances/page.tsx
+++ b/frontend/app/performances/page.tsx
@@ -31,7 +31,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { getPerformanceImageUrl } from "@/lib/utils";
 import type { PerformancePageResponse } from "../../src/types/performance";
-import { formatKSTDateTime } from "@/src/utils/date";
+import { format, parseISO, addHours } from "date-fns";
 
 export default function PerformancesPage() {
     const searchParams = useSearchParams();
@@ -322,13 +322,9 @@ export default function PerformancesPage() {
                                                     <div className="flex items-center">
                                                         <Calendar className="mr-1 h-3.5 w-3.5" />
                                                         <span className="text-white">
-                                                            {formatKSTDateTime(
-                                                                performance.startDate
-                                                            )}{" "}
+                                                            {format(addHours(parseISO(performance.startDate), 9), 'yyyy.MM.dd')}{" "}
                                                             ~{" "}
-                                                            {formatKSTDateTime(
-                                                                performance.endDate
-                                                            )}
+                                                            {format(addHours(parseISO(performance.endDate), 9), 'yyyy.MM.dd')}
                                                         </span>
                                                     </div>
                                                 </div>
@@ -344,13 +340,9 @@ export default function PerformancesPage() {
                                                         {performance.venue}
                                                     </span>
                                                     <span className="text-muted-foreground">
-                                                        {formatKSTDateTime(
-                                                            performance.startDate
-                                                        )}{" "}
+                                                        {format(addHours(parseISO(performance.startDate), 9), 'yyyy.MM.dd')}{" "}
                                                         ~{" "}
-                                                        {formatKSTDateTime(
-                                                            performance.endDate
-                                                        )}
+                                                        {format(addHours(parseISO(performance.endDate), 9), 'yyyy.MM.dd')}
                                                     </span>
                                                 </div>
                                             </div>

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -36,10 +36,10 @@ export function Footer() {
                   <Link href="/privacy">개인정보처리방침</Link>
                 </Button>
               </div>
-              <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
                 © 2024 TICKET4U. All rights reserved.
-              </p>
-            </div>
+            </p>
+          </div>
           </div>
         </div>
       </div>

--- a/frontend/components/recommended-performances.tsx
+++ b/frontend/components/recommended-performances.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Performance } from '@/src/api/performance'
 import { getPerformanceImageUrl } from '@/lib/utils'
+import { formatKSTDate } from "@/src/utils/date"
 
 interface RecommendedPerformancesProps {
   categoryPerformances: {
@@ -189,7 +190,7 @@ export function RecommendedPerformances({ categoryPerformances }: RecommendedPer
                                 <span className="font-medium truncate">{performance.venue}</span>
                               </div>
                               <div className="text-sm text-muted-foreground/80">
-                                <span>{new Date(performance.startDate).toLocaleDateString()} ~ {new Date(performance.endDate).toLocaleDateString()}</span>
+                                <span>{formatKSTDate(performance.startDate)} ~ {formatKSTDate(performance.endDate)}</span>
                               </div>
                             </div>
                           </div>

--- a/frontend/components/reservation-calendar-modal-fixed.tsx
+++ b/frontend/components/reservation-calendar-modal-fixed.tsx
@@ -35,7 +35,7 @@ import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { CustomCalendar } from "@/components/custom-calendar";
 import { createReservation, getPerformanceDetail } from "@/src/api/api";
-import { formatKSTDateTime } from "@/src/utils/date";
+import { formatKSTDateTime, formatKSTDate, formatKSTTime } from "@/src/utils/date";
 
 interface PerformanceSchedule {
     id: number;
@@ -134,8 +134,7 @@ export function ReservationCalendarModalFixed({
     const sessionsByDate =
         performance?.schedules.reduce((acc, schedule) => {
             if (schedule.isCanceled) return acc;
-            const dateStr = format(parseISO(schedule.startTime), "yyyy-MM-dd");
-            console.log("Processing schedule date:", dateStr);
+            const dateStr = formatKSTDate(schedule.startTime);
             if (!acc[dateStr]) {
                 acc[dateStr] = [];
             }
@@ -150,10 +149,8 @@ export function ReservationCalendarModalFixed({
 
     // 선택한 날짜에 해당하는 세션들
     const selectedDateStr = initialSelectedDate
-        ? format(initialSelectedDate, "yyyy-MM-dd")
+        ? formatKSTDate(initialSelectedDate.toISOString())
         : null;
-    console.log("Selected date string:", selectedDateStr);
-    console.log("Available dates:", Object.keys(sessionsByDate));
 
     const sessionsForSelectedDate = selectedDateStr
         ? sessionsByDate[selectedDateStr] || []
@@ -162,7 +159,7 @@ export function ReservationCalendarModalFixed({
     console.log("Selected Date:", initialSelectedDate);
     console.log(
         "Formatted Selected Date:",
-        initialSelectedDate ? format(initialSelectedDate, "yyyy-MM-dd") : null
+        initialSelectedDate ? formatKSTDate(initialSelectedDate.toISOString()) : null
     );
     console.log("Sessions By Date:", sessionsByDate);
     console.log("Sessions For Selected Date:", sessionsForSelectedDate);
@@ -333,7 +330,7 @@ export function ReservationCalendarModalFixed({
                                     <CalendarIcon className="h-5 w-5 text-muted-foreground" />
                                     <span className="font-medium">
                                         {initialSelectedDate
-                                            ? formatDateSafely(
+                                            ? formatKSTDate(
                                                   initialSelectedDate.toISOString()
                                               )
                                             : "날짜를 선택해주세요"}
@@ -384,13 +381,9 @@ export function ReservationCalendarModalFixed({
                                                         >
                                                             <div className="flex justify-between items-center">
                                                                 <span className="font-medium">
-                                                                    {formatTime(
-                                                                        schedule.startTime
-                                                                    )}{" "}
+                                                                    {formatKSTTime(schedule.startTime)}{" "}
                                                                     -{" "}
-                                                                    {formatTime(
-                                                                        schedule.endTime
-                                                                    )}
+                                                                    {formatKSTTime(schedule.endTime)}
                                                                 </span>
                                                                 <span className="text-sm font-medium">
                                                                     {performance?.price?.toLocaleString()}
@@ -399,9 +392,7 @@ export function ReservationCalendarModalFixed({
                                                             </div>
                                                             <div className="text-xs text-muted-foreground flex justify-between items-center mt-1">
                                                                 <span>
-                                                                    {formatDateSafely(
-                                                                        schedule.startTime
-                                                                    )}
+                                                                    {formatKSTDate(schedule.startTime)}
                                                                 </span>
                                                                 <div className="flex items-center gap-1">
                                                                     {soldOut ? (

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,9 @@ const nextConfig = {
   images: {
     domains: ['d290kzvpuy1puq.cloudfront.net', 'd3l7tgeznk7sw9.cloudfront.net'],
   },
+  env: {
+    TZ: 'Asia/Seoul'
+  }
 }
 
 module.exports = nextConfig 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
                 "clsx": "^2.1.1",
                 "cmdk": "latest",
                 "date-fns": "^4.1.0",
+                "date-fns-tz": "^3.2.0",
                 "dayjs": "^1.11.13",
                 "embla-carousel-react": "8.5.1",
                 "input-otp": "1.4.1",
@@ -4720,6 +4721,15 @@
             "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
             "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
             "license": "MIT"
+        },
+        "node_modules/date-fns-tz": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+            "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "date-fns": "^3.0.0 || ^4.0.0"
+            }
         },
         "node_modules/dayjs": {
             "version": "1.11.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
         "clsx": "^2.1.1",
         "cmdk": "latest",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "dayjs": "^1.11.13",
         "embla-carousel-react": "8.5.1",
         "input-otp": "1.4.1",

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,13 +1,37 @@
-import { parseISO, addHours, format } from "date-fns";
+import { parseISO } from "date-fns";
+import { ko } from "date-fns/locale";
+import { formatInTimeZone } from 'date-fns-tz';
+
+const TIMEZONE = 'Asia/Seoul';
 
 /**
  * UTC ISO 문자열을 KST로 변환해 'yyyy년 MM월 dd일 HH:mm' 포맷으로 반환
  */
 export function formatKSTDateTime(dateString: string): string {
   try {
-    const date = parseISO(dateString);
-    const kstDate = addHours(date, 9); // UTC to KST
-    return format(kstDate, "yyyy년 MM월 dd일 HH:mm");
+    return formatInTimeZone(parseISO(dateString), TIMEZONE, "yyyy년 MM월 dd일 HH:mm", { locale: ko });
+  } catch {
+    return dateString;
+  }
+}
+
+/**
+ * UTC ISO 문자열을 KST로 변환해 'yyyy.MM.dd' 포맷으로 반환
+ */
+export function formatKSTDate(dateString: string): string {
+  try {
+    return formatInTimeZone(parseISO(dateString), TIMEZONE, "yyyy.MM.dd", { locale: ko });
+  } catch {
+    return dateString;
+  }
+}
+
+/**
+ * UTC ISO 문자열을 KST로 변환해 'HH:mm' 포맷으로 반환
+ */
+export function formatKSTTime(dateString: string): string {
+  try {
+    return formatInTimeZone(parseISO(dateString), TIMEZONE, "HH:mm", { locale: ko });
   } catch {
     return dateString;
   }


### PR DESCRIPTION
# 현재 문제상황
1. DB에 저장은 KST로 잘 됨 (jdbc 커넥션 설정에 타임존을 아시아로 설정해둠)
2. 스프링에서 시간값들 타입을 LocalDateTime으로 지정함 (OffsetDateTime 이라는 타입도 있음 -> 타임존 오프셋 지정할 수 있음)
3. 그래서 시간이 저장은 되는데 **타임존 오프셋 정보가 없이 저장이 되고 있음** -> 어디 기준의 시간인지 모름
4. 프론트에서 시간을 받았는데 타임존 기준을 모름 -> UTC로 해석해버림
5. MockDataLoader가 저장하는 시간 값이랑 직접 로컬 브라우저에서 DB에 저장하는 시간값이 달라서 혼란
6. 자바스크립트 Date는 안그래도 동작 이상하기로 유명한데 프론트 내부에서 시간을 다루는 함수가 중구난방임 
7. 스프링부트 response Dto랑 Mapper를 전부 OffsetDateTime으로 수정하기엔 시간이 없음
8. **직접 시나리오 테스트를 하면서 한 페이지마다 직접 보정을 해나가는 수밖에 없음**

## 📝 요약(Summary)
src/utils/date.ts 에 타임존을 고정시켜서 시간을 파싱하는 함수를 생성해서
메인 인덱스페이지
공연목록페이지
공연상세페이지
에서 사용하도록 수정했습니다

상진님이 예매 모달창 작업은 해주신 것 같으니까 나중에 conflict 해결할 때 상진님걸로 합치면 될 것 같습니다




